### PR TITLE
Added the ability to see the currently loaded modelURL

### DIFF
--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -113,7 +113,7 @@ export class Wllama {
     if (modelUrl.length === 0) {
       throw new Error('modelUrl must be an URL or a list of URLs (in the correct order)');
     }
-    const ggufBuffers = await loadBinaryResource(modelUrl, config.n_download_parallel ?? 3);
+    const ggufBuffers = await loadBinaryResource(modelUrl, config.n_download_parallel ?? 3, config.progressCallback ?? function(url,progress){console.log("Wllama download progress:", url, progress)});
     return await this.loadModel(ggufBuffers, config);
   }
 

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -67,6 +67,7 @@ export interface SamplingConfig {
 export class Wllama {
   private proxy: ProxyToWorker = null as any;
   private pathConfig: AssetsPathConfig;
+  private modelUrl?: string | Array | null = null;
   private useMultiThread: boolean = false;
   private useEmbeddings: boolean = false;
   // available when loaded
@@ -113,6 +114,7 @@ export class Wllama {
     if (modelUrl.length === 0) {
       throw new Error('modelUrl must be an URL or a list of URLs (in the correct order)');
     }
+    this.modelUrl = modelUrl;
     const ggufBuffers = await loadBinaryResource(modelUrl, config.n_download_parallel ?? 3, config.progressCallback ?? function(url,progress){console.log("Wllama download progress:", url, progress)});
     return await this.loadModel(ggufBuffers, config);
   }


### PR DESCRIPTION
Being able to see the currently loaded model URL can be useful.

I wasn't sure how to create a separate request for these two lines of code.

```
export class Wllama {
    proxy = null;
    pathConfig;
    private modelUrl?: string | Array | null = null;
```

and

```
async loadModelFromUrl(modelUrl: string | string[], config: LoadModelConfig): Promise<void> {
    if (modelUrl.length === 0) {
      throw new Error('modelUrl must be an URL or a list of URLs (in the correct order)');
    }
    this.modelUrl = modelUrl;
```