### PR TITLE
Include `progressCallback` to the usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,19 @@ import { Wllama } from './esm/index.js';
   // Automatically switch between single-thread and multi-thread version based on browser support
   // If you want to enforce single-thread, add { "n_threads": 1 } to LoadModelConfig
   const wllama = new Wllama(CONFIG_PATHS);
-  await wllama.loadModelFromUrl('https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf', {});
+  // Define a function for tracking the model download progress
+  const progressCallback =  ({ loaded, total }) => {
+    // Calculate the progress as a percentage
+    const progressPercentage = Math.round((loaded / total) * 100);
+    // Log the progress in a user-friendly format
+    console.log(`Downloading... ${progressPercentage}%`);
+  };
+  await wllama.loadModelFromUrl(
+    "https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf",
+    {
+      progressCallback,
+    }
+  );
   const outputText = await wllama.createCompletion(elemInput.value, {
     nPredict: 50,
     sampling: {


### PR DESCRIPTION
As a follow-up for:
- https://github.com/ngxson/wllama/pull/13

I suggest adding the `progressCallback` to the main example for it being an important feature.