### PR TITLE
Internally generate the model URL array when the provided URL for `loadModelFromUrl` method is from a single shard of a model split with the `gguf-split` tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,13 @@ We use `gguf-split` to split a big gguf file into smaller files. You can downloa
 ./gguf-split --split-max-size 512M ./my_model.gguf ./my_model
 ```
 
-This will output files ending with `-00001-of-00003.gguf`, `-00002-of-00003.gguf`,...
+This will output files ending with `-00001-of-00003.gguf`, `-00002-of-00003.gguf`, and so on.
 
-You can then give a list of uploaded files to `loadModelFromUrl`:
+You can then pass to `loadModelFromUrl` the URL of the first file and it will automatically load all the chunks:
 
 ```js
 await wllama.loadModelFromUrl(
-  [
-    'https://huggingface.co/ngxson/tinyllama_split_test/resolve/main/stories15M-q8_0-00001-of-00003.gguf',
-    'https://huggingface.co/ngxson/tinyllama_split_test/resolve/main/stories15M-q8_0-00002-of-00003.gguf',
-    'https://huggingface.co/ngxson/tinyllama_split_test/resolve/main/stories15M-q8_0-00003-of-00003.gguf',
-  ],
+  'https://huggingface.co/ngxson/tinyllama_split_test/resolve/main/stories15M-q8_0-00001-of-00003.gguf',
   {
     parallelDownloads: 5, // optional: maximum files to download in parallel (default: 3)
   },

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -215,7 +215,7 @@ export class Wllama {
   private parseModelUrl(modelUrl: string | string[]): string[] {
     if (Array.isArray(modelUrl)) return modelUrl;
   
-    const urlPartsRegex = /(.*)-(\d{5})-of-(\d{5})\.gguf$/;
+    const urlPartsRegex = /(?<baseURL>.*)-(?<current>\d{5})-of-(?<total>\d{5})\.gguf$/;
   
     const matches = modelUrl.match(urlPartsRegex);
   

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -17,7 +17,7 @@ export interface WllamaConfig {
     warn: typeof console.warn,
     error: typeof console.error,
   },
-  };
+};
 
 export interface AssetsPathConfig {
   'single-thread/wllama.js': string,
@@ -97,7 +97,7 @@ export interface ChatCompletionOptions {
   }): any,
   sampling?: SamplingConfig,
   /**
-   * List of custom token IDs for stopping the generation.
+   * List of custom token IDs for stopping the generation.  
    * Note: To convert from text to token ID, use lookupToken()
    */
   stopTokens?: number[],
@@ -111,7 +111,7 @@ export interface ModelMetadata {
     nLayer: number;
   },
   meta: Record<string, string>,
-  };
+};
 
 /**
  * Logger preset with debug messages suppressed
@@ -150,9 +150,9 @@ export class Wllama {
 
   /**
    * Get token ID associated to BOS (begin of sentence) token.
-   *
+   * 
    * NOTE: This can only being used after `loadModel` is called.
-   *
+   * 
    * @returns -1 if the model is not loaded.
    */
   getBOS(): number {
@@ -161,9 +161,9 @@ export class Wllama {
 
   /**
    * Get token ID associated to EOS (end of sentence) token.
-   *
+   * 
    * NOTE: This can only being used after `loadModel` is called.
-   *
+   * 
    * @returns -1 if the model is not loaded.
    */
   getEOS(): number {
@@ -172,9 +172,9 @@ export class Wllama {
 
   /**
    * Get token ID associated to EOT (end of turn) token.
-   *
+   * 
    * NOTE: This can only being used after `loadModel` is called.
-   *
+   * 
    * @returns -1 if the model is not loaded.
    */
   getEOT(): number {
@@ -183,9 +183,9 @@ export class Wllama {
 
   /**
    * Get model hyper-parameters and metadata
-   *
+   * 
    * NOTE: This can only being used after `loadModel` is called.
-   *
+   * 
    * @returns ModelMetadata
    */
   getModelMetadata(): ModelMetadata {
@@ -197,9 +197,9 @@ export class Wllama {
 
   /**
    * Check if we're currently using multi-thread build.
-   *
+   * 
    * NOTE: This can only being used after `loadModel` is called.
-   *
+   * 
    * @returns true if multi-thread is used.
    */
   isMultithread(): boolean {
@@ -230,7 +230,7 @@ export class Wllama {
   /**
    * Load model from a given URL (or a list of URLs, in case the model is splitted into smaller files)
    * @param modelUrl URL or list of URLs (in the correct order)
-   * @param config
+   * @param config 
    */
   async loadModelFromUrl(modelUrl: string | string[], config: DownloadModelConfig = {}): Promise<void> {
     if (modelUrl.length === 0) {
@@ -252,9 +252,9 @@ export class Wllama {
 
   /**
    * Load model from a given list of Blob.
-   *
+   * 
    * You can pass multiple buffers into the function (in case the model contains multiple shards).
-   *
+   * 
    * @param ggufBlobs List of Blob that holds data of gguf file.
    * @param config LoadModelConfig
    */
@@ -287,11 +287,11 @@ export class Wllama {
         'wllama.js': absoluteUrl(this.pathConfig['multi-thread/wllama.js']!!),
         'wllama.wasm': absoluteUrl(this.pathConfig['multi-thread/wllama.wasm']!!),
         'wllama.worker.mjs': absoluteUrl(this.pathConfig['multi-thread/wllama.worker.mjs']!!),
-        }
+      }
       : {
         'wllama.js': absoluteUrl(this.pathConfig['single-thread/wllama.js']),
         'wllama.wasm': absoluteUrl(this.pathConfig['single-thread/wllama.wasm']),
-        };
+      };
     this.proxy = new ProxyToWorker(
       mPathConfig,
       this.useMultiThread ? nbThreads : 1,
@@ -300,10 +300,10 @@ export class Wllama {
     );
     // TODO: files maybe out-of-order
     await this.proxy.moduleInit(blobs.map((blob, i) => ({
-        name: hasMultipleBuffers
-          ? `model-${padDigits(i + 1, 5)}-of-${padDigits(blobs.length, 5)}.gguf`
+      name: hasMultipleBuffers
+        ? `model-${padDigits(i + 1, 5)}-of-${padDigits(blobs.length, 5)}.gguf`
         : 'model.gguf',
-        blob,
+      blob,
     })));
     // run it
     const startResult: any = await this.proxy.wllamaStart();
@@ -383,7 +383,7 @@ export class Wllama {
   /**
    * Make completion for a given text.
    * @param prompt Input text
-   * @param options
+   * @param options 
    * @returns Output completion text (only the completion part)
    */
   async createCompletion(prompt: string, options: ChatCompletionOptions): Promise<string> {
@@ -429,8 +429,8 @@ export class Wllama {
   // Low level API
 
   /**
-   * Create or reset the ctx_sampling
-   * @param config
+   * Create or reset the ctx_sampling 
+   * @param config 
    * @param pastTokens In case re-initializing the ctx_sampling, you can re-import past tokens into the new context
    */
   async samplingInit(config: SamplingConfig, pastTokens: number[] = []): Promise<void> {
@@ -445,7 +445,7 @@ export class Wllama {
   }
 
   /**
-   * Get a list of pieces in vocab.
+   * Get a list of pieces in vocab.  
    * NOTE: This function is slow, should only be used once.
    * @returns A list of Uint8Array. The nth element in the list associated to nth token in vocab
    */
@@ -455,9 +455,9 @@ export class Wllama {
   }
 
   /**
-   * Lookup to see if a token exist in vocab or not. Useful for searching special tokens like "<|im_start|>"
-   * NOTE: It will match the whole token, so do not use it as a replacement for tokenize()
-   * @param piece
+   * Lookup to see if a token exist in vocab or not. Useful for searching special tokens like "<|im_start|>"  
+   * NOTE: It will match the whole token, so do not use it as a replacement for tokenize()  
+   * @param piece 
    * @returns Token ID associated to the given piece. Returns -1 if cannot find the token.
    */
   async lookupToken(piece: string): Promise<number> {
@@ -471,7 +471,7 @@ export class Wllama {
 
   /**
    * Convert a given text to list of tokens
-   * @param text
+   * @param text 
    * @param special Should split special tokens?
    * @returns List of token ID
    */
@@ -485,7 +485,7 @@ export class Wllama {
 
   /**
    * Convert a list of tokens to text
-   * @param tokens
+   * @param tokens 
    * @returns Uint8Array, which maybe an unfinished unicode
    */
   async detokenize(tokens: number[]): Promise<Uint8Array> {
@@ -496,7 +496,7 @@ export class Wllama {
   /**
    * Run llama_decode()
    * @param tokens A list of tokens to be decoded
-   * @param options
+   * @param options 
    * @returns n_past (number of tokens so far in the sequence)
    */
   async decode(tokens: number[], options: {
@@ -530,7 +530,7 @@ export class Wllama {
 
   /**
    * Accept and save a new token to ctx_sampling
-   * @param tokens
+   * @param tokens 
    */
   async samplingAccept(tokens: number[]): Promise<void> {
     const result = await this.proxy.wllamaAction('sampling_accept', { tokens });
@@ -551,7 +551,7 @@ export class Wllama {
 
   /**
    * Calculate embeddings for a given list of tokens. Output vector is always normalized
-   * @param tokens
+   * @param tokens 
    * @returns A list of number represents an embedding vector of N dimensions
    */
   async embeddings(tokens: number[]): Promise<number[]> {
@@ -568,8 +568,8 @@ export class Wllama {
   /**
    * Remove and shift some tokens from KV cache.
    * Keep n_keep, remove n_discard then shift the rest
-   * @param nKeep
-   * @param nDiscard
+   * @param nKeep 
+   * @param nDiscard 
    */
   async kvRemove(nKeep: number, nDiscard: number): Promise<void> {
     const result = await this.proxy.wllamaAction('kv_remove', {
@@ -592,9 +592,9 @@ export class Wllama {
   }
 
   /**
-   * Save session to file (virtual file system)
+   * Save session to file (virtual file system)  
    * TODO: add ability to download the file
-   * @param filePath
+   * @param filePath 
    * @returns List of tokens saved to the file
    */
   async sessionSave(filePath: string): Promise<{ tokens: number[] }> {
@@ -603,10 +603,10 @@ export class Wllama {
   }
 
   /**
-   * Load session from file (virtual file system)
+   * Load session from file (virtual file system)  
    * TODO: add ability to download the file
-   * @param filePath
-   *
+   * @param filePath 
+   * 
    */
   async sessionLoad(filePath: string): Promise<void> {
     const result = await this.proxy.wllamaAction('session_load', { session_path: filePath });
@@ -616,7 +616,7 @@ export class Wllama {
       throw new Error('sessionLoad unknown error');
     }
   }
-
+  
   /**
    * Unload the model and free all memory
    */

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -17,7 +17,7 @@ export interface WllamaConfig {
     warn: typeof console.warn,
     error: typeof console.error,
   },
-};
+  };
 
 export interface AssetsPathConfig {
   'single-thread/wllama.js': string,
@@ -97,7 +97,7 @@ export interface ChatCompletionOptions {
   }): any,
   sampling?: SamplingConfig,
   /**
-   * List of custom token IDs for stopping the generation.  
+   * List of custom token IDs for stopping the generation.
    * Note: To convert from text to token ID, use lookupToken()
    */
   stopTokens?: number[],
@@ -111,7 +111,7 @@ export interface ModelMetadata {
     nLayer: number;
   },
   meta: Record<string, string>,
-};
+  };
 
 /**
  * Logger preset with debug messages suppressed
@@ -150,9 +150,9 @@ export class Wllama {
 
   /**
    * Get token ID associated to BOS (begin of sentence) token.
-   * 
+   *
    * NOTE: This can only being used after `loadModel` is called.
-   * 
+   *
    * @returns -1 if the model is not loaded.
    */
   getBOS(): number {
@@ -161,9 +161,9 @@ export class Wllama {
 
   /**
    * Get token ID associated to EOS (end of sentence) token.
-   * 
+   *
    * NOTE: This can only being used after `loadModel` is called.
-   * 
+   *
    * @returns -1 if the model is not loaded.
    */
   getEOS(): number {
@@ -172,9 +172,9 @@ export class Wllama {
 
   /**
    * Get token ID associated to EOT (end of turn) token.
-   * 
+   *
    * NOTE: This can only being used after `loadModel` is called.
-   * 
+   *
    * @returns -1 if the model is not loaded.
    */
   getEOT(): number {
@@ -183,9 +183,9 @@ export class Wllama {
 
   /**
    * Get model hyper-parameters and metadata
-   * 
+   *
    * NOTE: This can only being used after `loadModel` is called.
-   * 
+   *
    * @returns ModelMetadata
    */
   getModelMetadata(): ModelMetadata {
@@ -197,9 +197,9 @@ export class Wllama {
 
   /**
    * Check if we're currently using multi-thread build.
-   * 
+   *
    * NOTE: This can only being used after `loadModel` is called.
-   * 
+   *
    * @returns true if multi-thread is used.
    */
   isMultithread(): boolean {
@@ -211,32 +211,33 @@ export class Wllama {
    * If the input URL is an array, it returns the array itself.
    * If the input URL is a string in the `gguf-split` format, it returns an array containing the URL of each shard in ascending order.
    * Otherwise, it returns an array containing the input URL as a single element array.
+   * @param modelUrl URL or list of URLs
    */
   private parseModelUrl(modelUrl: string | string[]): string[] {
     if (Array.isArray(modelUrl)) return modelUrl;
-  
+
     const urlPartsRegex = /(?<baseURL>.*)-(?<current>\d{5})-of-(?<total>\d{5})\.gguf$/;
-  
+
     const matches = modelUrl.match(urlPartsRegex);
-  
+
     if (!matches || matches.length !== 4) return [modelUrl];
-  
+
     const baseURL = matches[1];
-  
+
     const paddedShardsAmount = matches[3];
-  
+
     const paddedShardNumbers = Array.from(
       { length: Number(paddedShardsAmount) },
       (_, i) => (i + 1).toString().padStart(5, '0')
     );
-  
+
     return paddedShardNumbers.map((paddedShardNumber) => `${baseURL}-${paddedShardNumber}-of-${paddedShardsAmount}.gguf`);
   }
 
   /**
    * Load model from a given URL (or a list of URLs, in case the model is splitted into smaller files)
    * @param modelUrl URL or list of URLs (in the correct order)
-   * @param config 
+   * @param config
    */
   async loadModelFromUrl(modelUrl: string | string[], config: DownloadModelConfig = {}): Promise<void> {
     if (modelUrl.length === 0) {
@@ -258,9 +259,9 @@ export class Wllama {
 
   /**
    * Load model from a given list of Blob.
-   * 
+   *
    * You can pass multiple buffers into the function (in case the model contains multiple shards).
-   * 
+   *
    * @param ggufBlobs List of Blob that holds data of gguf file.
    * @param config LoadModelConfig
    */
@@ -293,11 +294,11 @@ export class Wllama {
         'wllama.js': absoluteUrl(this.pathConfig['multi-thread/wllama.js']!!),
         'wllama.wasm': absoluteUrl(this.pathConfig['multi-thread/wllama.wasm']!!),
         'wllama.worker.mjs': absoluteUrl(this.pathConfig['multi-thread/wllama.worker.mjs']!!),
-      }
+        }
       : {
         'wllama.js': absoluteUrl(this.pathConfig['single-thread/wllama.js']),
         'wllama.wasm': absoluteUrl(this.pathConfig['single-thread/wllama.wasm']),
-      };
+        };
     this.proxy = new ProxyToWorker(
       mPathConfig,
       this.useMultiThread ? nbThreads : 1,
@@ -306,10 +307,10 @@ export class Wllama {
     );
     // TODO: files maybe out-of-order
     await this.proxy.moduleInit(blobs.map((blob, i) => ({
-      name: hasMultipleBuffers
-        ? `model-${padDigits(i + 1, 5)}-of-${padDigits(blobs.length, 5)}.gguf`
+        name: hasMultipleBuffers
+          ? `model-${padDigits(i + 1, 5)}-of-${padDigits(blobs.length, 5)}.gguf`
         : 'model.gguf',
-      blob,
+        blob,
     })));
     // run it
     const startResult: any = await this.proxy.wllamaStart();
@@ -389,7 +390,7 @@ export class Wllama {
   /**
    * Make completion for a given text.
    * @param prompt Input text
-   * @param options 
+   * @param options
    * @returns Output completion text (only the completion part)
    */
   async createCompletion(prompt: string, options: ChatCompletionOptions): Promise<string> {
@@ -435,8 +436,8 @@ export class Wllama {
   // Low level API
 
   /**
-   * Create or reset the ctx_sampling 
-   * @param config 
+   * Create or reset the ctx_sampling
+   * @param config
    * @param pastTokens In case re-initializing the ctx_sampling, you can re-import past tokens into the new context
    */
   async samplingInit(config: SamplingConfig, pastTokens: number[] = []): Promise<void> {
@@ -451,7 +452,7 @@ export class Wllama {
   }
 
   /**
-   * Get a list of pieces in vocab.  
+   * Get a list of pieces in vocab.
    * NOTE: This function is slow, should only be used once.
    * @returns A list of Uint8Array. The nth element in the list associated to nth token in vocab
    */
@@ -461,9 +462,9 @@ export class Wllama {
   }
 
   /**
-   * Lookup to see if a token exist in vocab or not. Useful for searching special tokens like "<|im_start|>"  
-   * NOTE: It will match the whole token, so do not use it as a replacement for tokenize()  
-   * @param piece 
+   * Lookup to see if a token exist in vocab or not. Useful for searching special tokens like "<|im_start|>"
+   * NOTE: It will match the whole token, so do not use it as a replacement for tokenize()
+   * @param piece
    * @returns Token ID associated to the given piece. Returns -1 if cannot find the token.
    */
   async lookupToken(piece: string): Promise<number> {
@@ -477,7 +478,7 @@ export class Wllama {
 
   /**
    * Convert a given text to list of tokens
-   * @param text 
+   * @param text
    * @param special Should split special tokens?
    * @returns List of token ID
    */
@@ -491,7 +492,7 @@ export class Wllama {
 
   /**
    * Convert a list of tokens to text
-   * @param tokens 
+   * @param tokens
    * @returns Uint8Array, which maybe an unfinished unicode
    */
   async detokenize(tokens: number[]): Promise<Uint8Array> {
@@ -502,7 +503,7 @@ export class Wllama {
   /**
    * Run llama_decode()
    * @param tokens A list of tokens to be decoded
-   * @param options 
+   * @param options
    * @returns n_past (number of tokens so far in the sequence)
    */
   async decode(tokens: number[], options: {
@@ -536,7 +537,7 @@ export class Wllama {
 
   /**
    * Accept and save a new token to ctx_sampling
-   * @param tokens 
+   * @param tokens
    */
   async samplingAccept(tokens: number[]): Promise<void> {
     const result = await this.proxy.wllamaAction('sampling_accept', { tokens });
@@ -557,7 +558,7 @@ export class Wllama {
 
   /**
    * Calculate embeddings for a given list of tokens. Output vector is always normalized
-   * @param tokens 
+   * @param tokens
    * @returns A list of number represents an embedding vector of N dimensions
    */
   async embeddings(tokens: number[]): Promise<number[]> {
@@ -574,8 +575,8 @@ export class Wllama {
   /**
    * Remove and shift some tokens from KV cache.
    * Keep n_keep, remove n_discard then shift the rest
-   * @param nKeep 
-   * @param nDiscard 
+   * @param nKeep
+   * @param nDiscard
    */
   async kvRemove(nKeep: number, nDiscard: number): Promise<void> {
     const result = await this.proxy.wllamaAction('kv_remove', {
@@ -598,9 +599,9 @@ export class Wllama {
   }
 
   /**
-   * Save session to file (virtual file system)  
+   * Save session to file (virtual file system)
    * TODO: add ability to download the file
-   * @param filePath 
+   * @param filePath
    * @returns List of tokens saved to the file
    */
   async sessionSave(filePath: string): Promise<{ tokens: number[] }> {
@@ -609,10 +610,10 @@ export class Wllama {
   }
 
   /**
-   * Load session from file (virtual file system)  
+   * Load session from file (virtual file system)
    * TODO: add ability to download the file
-   * @param filePath 
-   * 
+   * @param filePath
+   *
    */
   async sessionLoad(filePath: string): Promise<void> {
     const result = await this.proxy.wllamaAction('session_load', { session_path: filePath });
@@ -622,7 +623,7 @@ export class Wllama {
       throw new Error('sessionLoad unknown error');
     }
   }
-  
+
   /**
    * Unload the model and free all memory
    */

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -214,24 +214,17 @@ export class Wllama {
    * @param modelUrl URL or list of URLs
    */
   private parseModelUrl(modelUrl: string | string[]): string[] {
-    if (Array.isArray(modelUrl)) return modelUrl;
-
+    if (Array.isArray(modelUrl)) {
+      return modelUrl;
+    }
     const urlPartsRegex = /(?<baseURL>.*)-(?<current>\d{5})-of-(?<total>\d{5})\.gguf$/;
-
     const matches = modelUrl.match(urlPartsRegex);
-
-    if (!matches || matches.length !== 4) return [modelUrl];
-
-    const baseURL = matches[1];
-
-    const paddedShardsAmount = matches[3];
-
-    const paddedShardNumbers = Array.from(
-      { length: Number(paddedShardsAmount) },
-      (_, i) => (i + 1).toString().padStart(5, '0')
-    );
-
-    return paddedShardNumbers.map((paddedShardNumber) => `${baseURL}-${paddedShardNumber}-of-${paddedShardsAmount}.gguf`);
+    if (!matches || !matches.groups || Object.keys(matches.groups).length !== 3) {
+      return [modelUrl];
+    }
+    const { baseURL, total} = matches.groups
+    const paddedShardIds = Array.from({ length: Number(total) }, (_, index) => (index + 1).toString().padStart(5, '0'));
+    return paddedShardIds.map((current) => `${baseURL}-${current}-of-${total}.gguf`);
   }
 
   /**

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -212,7 +212,7 @@ export class Wllama {
    * If the input URL is a string in the `gguf-split` format, it returns an array containing the URL of each shard in ascending order.
    * Otherwise, it returns an array containing the input URL as a single element array.
    */
-  parseModelUrl(modelUrl: string | string[]) {
+  private parseModelUrl(modelUrl: string | string[]): string[] {
     if (Array.isArray(modelUrl)) return modelUrl;
   
     const urlPartsRegex = /(.*)-(\d{5})-of-(\d{5})\.gguf$/;

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -227,7 +227,7 @@ export class Wllama {
   
     const paddedShardNumbers = Array.from(
       { length: Number(paddedShardsAmount) },
-      (_, i) => (i + 1).toString().padStart(5, "0")
+      (_, i) => (i + 1).toString().padStart(5, '0')
     );
   
     return paddedShardNumbers.map((paddedShardNumber) => `${baseURL}-${paddedShardNumber}-of-${paddedShardsAmount}.gguf`);


### PR DESCRIPTION
Resolves #58

## Example

Loading a 7-shards model:

```typescript
import { Wllama } from './esm/index.js';

(async () => {
  const CONFIG_PATHS = {
    'single-thread/wllama.js'       : './esm/single-thread/wllama.js',
    'single-thread/wllama.wasm'     : './esm/single-thread/wllama.wasm',
    'multi-thread/wllama.js'        : './esm/multi-thread/wllama.js',
    'multi-thread/wllama.wasm'      : './esm/multi-thread/wllama.wasm',
    'multi-thread/wllama.worker.mjs': './esm/multi-thread/wllama.worker.mjs',
  };

  const wllama = new Wllama(CONFIG_PATHS);

  const progressCallback =  ({ loaded, total }) => {
    const progressPercentage = Math.round((loaded / total) * 100);
    console.log(`Downloading... ${progressPercentage}%`);
  };

  await wllama.loadModelFromUrl(
    "https://huggingface.co/Felladrin/gguf-sharded-Llama-160M-Chat-v1/resolve/main/Llama-160M-Chat-v1.Q8_0.shard-00001-of-00007.gguf",
    {
      progressCallback,
    }
  );

  const outputText = await wllama.createCompletion("The best way to become healthier is", {
    nPredict: 250,
    sampling: {
      temp: 0.5,
      top_k: 40,
      top_p: 0.9,
    },
  });

  console.log(outputText);
})();
```