### PR TITLE
Allow loading a model using relative path

### DIFF
--- a/src/downloader/multi-downloads.ts
+++ b/src/downloader/multi-downloads.ts
@@ -45,7 +45,7 @@ export class MultiDownloads {
   async run(): Promise<Blob[]> {
     // create all Blobs
     await Promise.all(this.tasks.map(async (task) => {
-      task.blob = await GGUFRemoteBlob.create(new URL(task.url), {
+      task.blob = await GGUFRemoteBlob.create(task.url, {
         logger: this.logger,
         useCache: this.useCache,
         startSignal: task.signalStart,

--- a/src/downloader/remote-blob.ts
+++ b/src/downloader/remote-blob.ts
@@ -25,7 +25,7 @@ interface GGUFRemoteBlobCreateOptions {
 }
 
 export class GGUFRemoteBlob extends Blob {
-  static async create(url: URL, opts?: GGUFRemoteBlobCreateOptions): Promise<Blob> {
+  static async create(url: RequestInfo | URL, opts?: GGUFRemoteBlobCreateOptions): Promise<Blob> {
     const customFetch = opts?.fetch ?? fetch;
     const response = await customFetch(url, { method: 'HEAD' });
 
@@ -62,7 +62,7 @@ export class GGUFRemoteBlob extends Blob {
     }
   }
 
-  private url: URL;
+  private url: RequestInfo | URL;
   private start: number;
   private end: number;
   private contentType: string;
@@ -72,7 +72,7 @@ export class GGUFRemoteBlob extends Blob {
   private progressCallback: ProgressCallback;
   private startSignal?: Promise<void>;
 
-  constructor(url: URL, start: number, end: number, contentType: string, full: boolean, customFetch: typeof fetch, additionals: {
+  constructor(url: RequestInfo | URL, start: number, end: number, contentType: string, full: boolean, customFetch: typeof fetch, additionals: {
     cachedStream?: ReadableStream,
     progressCallback: ProgressCallback,
     startSignal?: Promise<void>,


### PR DESCRIPTION
This makes Wllama correctly load the model from relative paths.

- Tested with locally loaded [Felladrin/gguf-sharded-Qwen1.5-0.5B-Chat](https://huggingface.co/Felladrin/gguf-sharded-Qwen1.5-0.5B-Chat) and [tinyllamas/stories15M-q4_0.gguf](https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories15M-q4_0.gguf).
- Fixes #63

## Tests

The following 4 ways of loading a model were tested:

```
wllama.loadModelFromUrl("models/Qwen1.5-0.5B-Chat.Q4_k_m.shard-00001-of-00003.gguf")

wllama.loadModelFromUrl("/models/Qwen1.5-0.5B-Chat.Q4_k_m.shard-00001-of-00003.gguf")

wllama.loadModelFromUrl("./models/Qwen1.5-0.5B-Chat.Q4_k_m.shard-00001-of-00003.gguf")

wllama.loadModelFromUrl("https://huggingface.co/Felladrin/gguf-sharded-Qwen1.5-0.5B-Chat/resolve/main/Qwen1.5-0.5B-Chat.Q4_k_m.shard-00001-of-00003.gguf")
```

It works for both non-sharded and sharded models. For example, this non-sharded model was also tested:

```
wllama.loadModelFromUrl("models/stories15M-q4_0.gguf")

wllama.loadModelFromUrl("/models/stories15M-q4_0.gguf")

wllama.loadModelFromUrl("./models/stories15M-q4_0.gguf")

wllama.loadModelFromUrl("https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories15M-q4_0.gguf")
```

## Screenshots

<img width="1449" alt="image" src="https://github.com/ngxson/wllama/assets/418083/9a3fc2af-37e5-46b7-a261-b05de842054d">

<img width="397" alt="image" src="https://github.com/ngxson/wllama/assets/418083/631127f6-23a0-4ea3-9316-9a9e0f0eabe7">

<img width="739" alt="image" src="https://github.com/ngxson/wllama/assets/418083/bc7ac8c2-6d1f-41ac-8d3f-79ffcd7f1d35">

<img width="1197" alt="image" src="https://github.com/ngxson/wllama/assets/418083/36e1ab8b-1ed2-4587-ba4c-274bbbcb726c">

## About typings

The type `RequestInfo | URL` comes from the argument from the browser's `fetch()`.

<img width="692" alt="image" src="https://github.com/ngxson/wllama/assets/418083/d2f5132d-534b-456e-8a9f-7791ebf6b6c5">