### PR TITLE
Git ignore also .DS_Store which are created by MacOS Finder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.DS_Store
 /cache
 /docs
 /dist


### PR DESCRIPTION
To prevent devs working with this repository on MacOS commiting `.DS_Store` files.