### PR TITLE
Add `downloadModel` function

### DIFF
--- a/src/downloader/multi-downloads.ts
+++ b/src/downloader/multi-downloads.ts
@@ -21,11 +21,13 @@ export class MultiDownloads {
   private useCache: boolean;
   private totalBytes: number = 0;
   private allowOffline: boolean;
+  private noTEE: boolean;
 
   constructor(logger: any, urls: string[], maxParallel: number, opts: {
     progressCallback?: ProgressCallback,
     useCache: boolean,
     allowOffline: boolean,
+    noTEE?: boolean,
   }) {
     this.tasks = urls.map(url => {
       // @ts-ignore
@@ -43,6 +45,7 @@ export class MultiDownloads {
     this.progressCallback = opts.progressCallback;
     this.useCache = opts.useCache;
     this.allowOffline = opts.allowOffline;
+    this.noTEE = !!opts.noTEE;
   }
 
   async run(): Promise<Blob[]> {
@@ -53,6 +56,7 @@ export class MultiDownloads {
         useCache: this.useCache,
         startSignal: task.signalStart,
         allowOffline: this.allowOffline,
+        noTEE: this.noTEE,
         progressCallback: ({ loaded }) => {
           task.loaded = loaded;
           this.updateProgress(task);

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -276,7 +276,35 @@ export class Wllama {
   }
 
   /**
+   * Download a model to cache, without loading it
+   * @param modelUrl URL or list of URLs (in the correct order)
+   * @param config 
+   */
+  async downloadModel(modelUrl: string | string[], config: DownloadModelConfig = {}): Promise<void> {
+    if (modelUrl.length === 0) {
+      throw new Error('modelUrl must be an URL or a list of URLs (in the correct order)');
+    }
+    if (config.useCache === false) {
+      throw new Error('useCache must not be false');
+    }
+    const multiDownloads = new MultiDownloads(
+      this.logger(),
+      this.parseModelUrl(modelUrl),
+      config.parallelDownloads ?? 3,
+      {
+        progressCallback: config.progressCallback,
+        useCache: true,
+        allowOffline: !!config.allowOffline,
+        noTEE: true,
+      }
+    );
+    await multiDownloads.run();
+  }
+
+  /**
    * Load model from a given URL (or a list of URLs, in case the model is splitted into smaller files)
+   * - If the model already been downloaded (via `downloadModel()`), then we will use the cached model
+   * - Else, we download the model from internet
    * @param modelUrl URL or list of URLs (in the correct order)
    * @param config 
    */


### PR DESCRIPTION
As the name suggested, this function allows user to download the model to cache, without loading it into memory.

The use case would be to allow application to have a "model manager" screen that allows:
- Download model via `downloadModel()`
- List all downloaded models using `CacheManager.list()`
- Delete a downloaded model using `CacheManager.delete()`