### PR TITLE
Fix nextjs build

### DIFF
--- a/src/model-manager.ts
+++ b/src/model-manager.ts
@@ -234,17 +234,13 @@ export class ModelManager {
     if (Array.isArray(modelUrl)) {
       return modelUrl;
     }
-    const urlPartsRegex =
-      /(?<baseURL>.*)-(?<current>\d{5})-of-(?<total>\d{5})\.gguf$/;
+    const urlPartsRegex = /-(\d{5})-of-(\d{5})\.gguf$/;
     const matches = modelUrl.match(urlPartsRegex);
-    if (
-      !matches ||
-      !matches.groups ||
-      Object.keys(matches.groups).length !== 3
-    ) {
+    if (!matches) {
       return [modelUrl];
     }
-    const { baseURL, total } = matches.groups;
+    const baseURL = modelUrl.replace(urlPartsRegex, '');
+    const total = matches[2];
     const paddedShardIds = Array.from({ length: Number(total) }, (_, index) =>
       (index + 1).toString().padStart(5, '0')
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ const textDecoder = new TextDecoder();
  * @param buffer
  * @returns a string
  */
-export const bufToText = (buffer: ArrayBuffer): string => {
+export const bufToText = (buffer: ArrayBuffer | Uint8Array): string => {
   return textDecoder.decode(buffer);
 };
 

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -623,6 +623,7 @@ export class Wllama {
       if (stopTokens.includes(sampled.token)) {
         break; // stop token
       }
+      // @ts-ignore Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBuffer>'
       outBuf = joinBuffers([outBuf, sampled.piece]);
       if (options.onNewToken) {
         options.onNewToken(sampled.token, sampled.piece, bufToText(outBuf), {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -190,6 +190,7 @@ export class ProxyToWorker {
           args: [fileId, value, offset],
           callbackId: this.taskId++,
         },
+        // @ts-ignore Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'
         [value.buffer]
       );
       offset += size;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -20,7 +20,7 @@
     "experimentalDecorators": true,
 
     "noEmit": false,
-    "module": "es2020",
+    "module": "es2015",
     "outDir": "esm",
     "rootDir": "./src",
     "baseUrl": ".",


### PR DESCRIPTION
Caused by mismatch `compilerOptions.module` between us and nextjs. Setting it to `es2015` for more compatibility.

Fix #137 