### PR TITLE
add support for async generator

### DIFF
--- a/examples/main/src/utils/utils.ts
+++ b/examples/main/src/utils/utils.ts
@@ -4,8 +4,6 @@ import { Message, Screen } from './types';
 import { Wllama } from '@wllama/wllama';
 import { DEFAULT_CHAT_TEMPLATE } from '../config';
 
-const textDecoder = new TextDecoder();
-
 export const delay = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -58,11 +56,13 @@ export const formatChat = async (
     return result + '<｜Assistant｜>';
   }
   const template = new Template(templateStr);
-  const bos_token: string = textDecoder.decode(
-    await modelWllama.detokenize([modelWllama.getBOS()])
+  const bos_token: string = await modelWllama.detokenize(
+    [modelWllama.getBOS()],
+    true
   );
-  const eos_token: string = textDecoder.decode(
-    await modelWllama.detokenize([modelWllama.getEOS()])
+  const eos_token: string = await modelWllama.detokenize(
+    [modelWllama.getEOS()],
+    true
   );
   return template.render({
     messages,

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -887,12 +887,12 @@ export class Wllama {
    * @param returnString Return a string instead of Uint8Array
    * @returns Uint8Array, which maybe an unfinished unicode
    */
-  async detokenize(tokens: number[], returnString: true): Promise<String>;
-  async detokenize(tokens: number[], returnString: false): Promise<Uint8Array>;
+  async detokenize(tokens: number[], returnString?: false): Promise<Uint8Array>;
+  async detokenize(tokens: number[], returnString: true): Promise<string>;
   async detokenize(
     tokens: number[],
-    returnString: boolean
-  ): Promise<Uint8Array | String> {
+    returnString: true | false = false
+  ): Promise<Uint8Array | string> {
     this.checkModelLoaded();
     const result = await this.proxy.wllamaAction<GlueMsgDetokenizeRes>(
       'detokenize',


### PR DESCRIPTION
Example usage:

```ts
const messages: WllamaChatMessage[] = [
  { role: 'system', content: 'You are helpful.' },
  { role: 'user', content: 'Hi!' },
  { role: 'assistant', content: 'Hello!' },
  { role: 'user', content: 'How are you?' },
];
const stream = await wllama.createChatCompletionGenerator(messages, {
  nPredict: 10,
  sampling: {
    temp: 0.0,
  },
});

for await (const chunk of stream) {
  console.log(chunk.currentText);
}
```