### PR TITLE
add "stream" option for AsyncIterator

### DIFF
--- a/src/wllama.test.ts
+++ b/src/wllama.test.ts
@@ -323,11 +323,12 @@ test.sequential('generates chat completion using async iterator', async () => {
     { role: 'assistant', content: 'Hello!' },
     { role: 'user', content: 'How are you?' },
   ];
-  const stream = await wllama.createChatCompletionGenerator(messages, {
+  const stream = await wllama.createChatCompletion(messages, {
     nPredict: 10,
     sampling: {
       temp: 0.0,
     },
+    stream: true,
   });
 
   let finalTokens: number[] = [];


### PR DESCRIPTION
Cont https://github.com/ngxson/wllama/pull/163

I decide to make `createCompletionGenerator` private and now we will return AsyncIterator if `stream` option is set:

```ts
const messages: WllamaChatMessage[] = [
  { role: 'system', content: 'You are helpful.' },
  { role: 'user', content: 'Hi!' },
  { role: 'assistant', content: 'Hello!' },
  { role: 'user', content: 'How are you?' },
];
const stream = await wllama.createChatCompletion(messages, {
  nPredict: 10,
  sampling: {
    temp: 0.0,
  },
  stream: true, // ADD THIS
});

for await (const chunk of stream) {
  console.log(chunk.currentText);
}
```