### PR TITLE
feat: support importing local GGUF models into cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,27 @@ const wllama = new Wllama(WasmFromCDN);
 // NOTE: this is not recommended, only use when you can't embed wasm files in your project
 ```
 
+### Import a local GGUF into cache
+
+If you want users to pick a local GGUF file and reuse it across page refreshes,
+you can import it into the `ModelManager` cache:
+
+```ts
+import { ModelManager, Wllama } from '@wllama/wllama';
+
+const modelManager = new ModelManager();
+const modelFile = fileInput.files?.[0];
+
+if (modelFile) {
+  const model = await modelManager.importFile(modelFile);
+  const wllama = new Wllama(CONFIG_PATHS);
+  await wllama.loadModel(model);
+}
+```
+
+Imported files are stored in OPFS, so they stay available until the user clears
+site data or removes them from cache.
+
 ### Split model
 
 Cases where we want to split the model:

--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -1,6 +1,10 @@
 # wllama main example
 
+Features:
+- Add custom GGUF models from Hugging Face
+- Import a local `.gguf` file into browser storage
+- Remember the last loaded model across refreshes
+
 TODO:
-- Load local gguf
 - Switching theme
 - Warning limitations on mobile

--- a/examples/main/src/components/ModelScreen.tsx
+++ b/examples/main/src/components/ModelScreen.tsx
@@ -394,7 +394,7 @@ function ModelCard({
         <div className="grow">
           <b>
             {m.isLocalFile
-              ? m.url.replace('local://', '')
+              ? m.hfPath
               : m.hfPath.replace(/-\d{5}-of-\d{5}/, '-(shards)')}
           </b>
           <br />

--- a/examples/main/src/components/ModelScreen.tsx
+++ b/examples/main/src/components/ModelScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { DEFAULT_INFERENCE_PARAMS, MAX_GGUF_SIZE } from '../config';
 import { toHumanReadableSize, useDebounce } from '../utils/utils';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ChangeEvent } from 'react';
 import ScreenWrapper from './ScreenWrapper';
 import { DisplayedModel } from '../utils/displayed-model';
 import { isValidGgufFile } from '@wllama/wllama';
@@ -151,10 +151,14 @@ export default function ModelScreen() {
 }
 
 function AddCustomModelDialog({ onClose }: { onClose(): void }) {
-  const { isLoadingModel, addCustomModel } = useWllama();
+  const { isLoadingModel, addCustomModel, addLocalModel } = useWllama();
+  const [activeTab, setActiveTab] = useState<'huggingface' | 'local'>(
+    'huggingface'
+  );
   const [hfRepo, setHfRepo] = useState<string>('');
   const [hfFile, setHfFile] = useState<string>('');
   const [hfFiles, setHfFiles] = useState<string[]>([]);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [abortSignal, setAbortSignal] = useState<AbortController>(
     new AbortController()
   );
@@ -199,7 +203,7 @@ function AddCustomModelDialog({ onClose }: { onClose(): void }) {
     }
   }, [hfFiles]);
 
-  const onSubmit = async () => {
+  const onSubmitHF = async () => {
     try {
       await addCustomModel(
         `https://huggingface.co/${hfRepo}/resolve/main/${hfFile}`
@@ -210,9 +214,32 @@ function AddCustomModelDialog({ onClose }: { onClose(): void }) {
     }
   };
 
+  const onSubmitLocal = async () => {
+    if (!selectedFile) return;
+    try {
+      await addLocalModel(selectedFile);
+      onClose();
+    } catch (e) {
+      setErr((e as any)?.message ?? 'unknown error');
+    }
+  };
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      if (!file.name.toLowerCase().endsWith('.gguf')) {
+        setErr('File must have .gguf extension');
+        setSelectedFile(null);
+        return;
+      }
+      setSelectedFile(file);
+      setErr(undefined);
+    }
+  };
+
   return (
     <dialog className="modal modal-open">
-      <div className="modal-box">
+      <div className="modal-box max-w-lg">
         <h3 className="font-bold text-lg">Add custom GGUF</h3>
         <div className="mt-4">
           Max GGUF file size is 2GB. If your model is bigger than 2GB, please{' '}
@@ -226,45 +253,110 @@ function AddCustomModelDialog({ onClose }: { onClose(): void }) {
           </a>{' '}
           to split it into smaller shards.
         </div>
-        <div className="mt-4">
-          <label className="input input-bordered flex items-center gap-2 mb-2">
-            HF repo
-            <input
-              type="text"
-              className="grow"
-              placeholder="{username}/{repo}"
-              value={hfRepo}
-              onChange={(e) => {
-                abortSignal.abort();
-                setHfRepo(e.target.value);
-                setAbortSignal(new AbortController());
-              }}
-            />
-          </label>
-          <select
-            className="select select-bordered w-full"
-            onChange={(e) => setHfFile(e.target.value)}
+
+        <div className="tabs tabs-boxed mt-6">
+          <button
+            className={`tab ${activeTab === 'huggingface' ? 'tab-active' : ''}`}
+            onClick={() => setActiveTab('huggingface')}
           >
-            <option value="">Select a model file</option>
-            {hfFiles.map((f) => (
-              <option key={f} value={f}>
-                {f}
-              </option>
-            ))}
-          </select>
+            From HuggingFace
+          </button>
+          <button
+            className={`tab ${activeTab === 'local' ? 'tab-active' : ''}`}
+            onClick={() => setActiveTab('local')}
+          >
+            From Local File
+          </button>
         </div>
+
+        {activeTab === 'huggingface' ? (
+          <div className="mt-4">
+            <label className="input input-bordered flex items-center gap-2 mb-2">
+              HF repo
+              <input
+                type="text"
+                className="grow"
+                placeholder="{username}/{repo}"
+                value={hfRepo}
+                onChange={(e) => {
+                  abortSignal.abort();
+                  setHfRepo(e.target.value);
+                  setAbortSignal(new AbortController());
+                }}
+              />
+            </label>
+            <select
+              className="select select-bordered w-full"
+              onChange={(e) => setHfFile(e.target.value)}
+              value={hfFile}
+            >
+              <option value="">Select a model file</option>
+              {hfFiles.map((f) => (
+                <option key={f} value={f}>
+                  {f}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <div className="mt-4">
+            <div className="form-control">
+              <label className="label">
+                <span className="label-text">
+                  Select a GGUF file from your device
+                </span>
+              </label>
+              <input
+                type="file"
+                className="file-input file-input-bordered w-full"
+                accept=".gguf"
+                onChange={handleFileChange}
+              />
+              {selectedFile && (
+                <label className="label">
+                  <span className="label-text-alt text-success">
+                    Selected: {selectedFile.name} (
+                    {(selectedFile.size / 1024 / 1024).toFixed(2)} MB)
+                  </span>
+                </label>
+              )}
+            </div>
+            <div className="alert alert-info mt-4 text-sm">
+              <span>
+                Note: Local files are cached in your browser and will persist
+                across page refreshes.
+              </span>
+            </div>
+          </div>
+        )}
+
         {err && <div className="mt-4 text-error">Error: {err}</div>}
         <div className="modal-action">
-          <button
-            className="btn btn-primary"
-            disabled={isLoadingModel || hfRepo.length < 2 || hfFile.length < 5}
-            onClick={onSubmit}
-          >
-            {isLoadingModel && (
-              <span className="loading loading-spinner"></span>
-            )}
-            Add model
-          </button>
+          {activeTab === 'huggingface' ? (
+            <button
+              className="btn btn-primary"
+              disabled={
+                isLoadingModel || hfRepo.length < 2 || hfFile.length < 5
+              }
+              onClick={onSubmitHF}
+            >
+              {isLoadingModel && (
+                <span className="loading loading-spinner"></span>
+              )}
+              Add model
+            </button>
+          ) : (
+            <button
+              className="btn btn-primary"
+              disabled={isLoadingModel || !selectedFile}
+              onClick={onSubmitLocal}
+            >
+              {isLoadingModel && (
+                <span className="loading loading-spinner"></span>
+              )}
+              Add model
+            </button>
+          )}
           <button className="btn" disabled={isLoadingModel} onClick={onClose}>
             Close
           </button>
@@ -300,10 +392,14 @@ function ModelCard({
     >
       <div className="card-body p-4 flex flex-row">
         <div className="grow">
-          <b>{m.hfPath.replace(/-\d{5}-of-\d{5}/, '-(shards)')}</b>
+          <b>
+            {m.isLocalFile
+              ? m.url.replace('local://', '')
+              : m.hfPath.replace(/-\d{5}-of-\d{5}/, '-(shards)')}
+          </b>
           <br />
           <small>
-            HF repo: {m.hfModel}
+            {m.isLocalFile ? 'Source: Local file' : `HF repo: ${m.hfModel}`}
             <br />
             Size: {toHumanReadableSize(m.size)}
             {m.size > MAX_GGUF_SIZE && (

--- a/examples/main/src/utils/custom-models.tsx
+++ b/examples/main/src/utils/custom-models.tsx
@@ -27,6 +27,31 @@ export async function verifyCustomModel(url: string): Promise<DisplayedModel> {
   return new DisplayedModel(_url, await getModelSize(_url), true, undefined);
 }
 
+/**
+ * Verify a local file is a valid GGUF file
+ * @param file The File object from file input
+ * @throws Error if file is invalid
+ */
+export async function verifyLocalFile(file: File): Promise<void> {
+  if (!file.name.toLowerCase().endsWith('.gguf')) {
+    throw new Error('File must have .gguf extension');
+  }
+
+  if (file.size >= MAX_GGUF_SIZE) {
+    throw new Error(
+      'GGUF file is too big (max. 2GB per file). Please split the file into smaller shards (learn more in "Guide")'
+    );
+  }
+
+  const headerSlice = file.slice(0, 4);
+  const headerBuf = await headerSlice.arrayBuffer();
+  if (!checkBuffer(new Uint8Array(headerBuf), ggufMagicNumber)) {
+    throw new Error(
+      'Not a valid gguf file: not starting with GGUF magic number'
+    );
+  }
+}
+
 const checkBuffer = (buffer: Uint8Array, header: Uint8Array) => {
   for (let i = 0; i < header.length; i++) {
     if (header[i] !== buffer[i]) {

--- a/examples/main/src/utils/displayed-model.tsx
+++ b/examples/main/src/utils/displayed-model.tsx
@@ -10,7 +10,7 @@ export class DisplayedModel {
   cachedModel?: Model;
 
   state: ModelState = ModelState.NOT_DOWNLOADED;
-  downloadPercent: number = -1; // from 0.0 to 1.0; -1 means not downloading
+  downloadPercent: number = -1;
 
   constructor(
     url: string,
@@ -21,11 +21,18 @@ export class DisplayedModel {
     this.url = url;
     this.size = size;
     this.isUserAdded = isUserAdded;
-    this.state = !!cachedModel ? ModelState.READY : ModelState.NOT_DOWNLOADED;
+    this.state = cachedModel ? ModelState.READY : ModelState.NOT_DOWNLOADED;
     this.cachedModel = cachedModel;
   }
 
+  get isLocalFile(): boolean {
+    return this.url.startsWith('local://');
+  }
+
   get hfModel() {
+    if (this.isLocalFile) {
+      return 'Local file';
+    }
     const parts = this.url
       .replace(/https:\/\/(huggingface.co|hf.co)\/+/, '')
       .split('/');
@@ -33,6 +40,9 @@ export class DisplayedModel {
   }
 
   get hfPath() {
+    if (this.isLocalFile) {
+      return this.url.replace('local://', '');
+    }
     const parts = this.url
       .replace(/https:\/\/(huggingface.co|hf.co)\/+/, '')
       .split('/');

--- a/examples/main/src/utils/displayed-model.tsx
+++ b/examples/main/src/utils/displayed-model.tsx
@@ -41,7 +41,8 @@ export class DisplayedModel {
 
   get hfPath() {
     if (this.isLocalFile) {
-      return this.url.replace('local://', '');
+      const encodedName = this.url.split('/').pop();
+      return decodeURIComponent(encodedName ?? this.url.replace('local://', ''));
     }
     const parts = this.url
       .replace(/https:\/\/(huggingface.co|hf.co)\/+/, '')

--- a/examples/main/src/utils/utils.ts
+++ b/examples/main/src/utils/utils.ts
@@ -12,7 +12,12 @@ export const useDidMount = (callback: () => any) =>
     callback();
   }, []);
 
-type StorageKey = 'conversations' | 'params' | 'welcome' | 'custom_models';
+type StorageKey =
+  | 'conversations'
+  | 'params'
+  | 'welcome'
+  | 'custom_models'
+  | 'loaded_model';
 
 export const WllamaStorage = {
   save<T>(key: StorageKey, data: T) {

--- a/examples/main/src/utils/wllama.context.tsx
+++ b/examples/main/src/utils/wllama.context.tsx
@@ -125,6 +125,8 @@ export const WllamaProvider = ({ children }: any) => {
         console.error('Failed to auto-load model:', e);
         WllamaStorage.save('loaded_model', undefined as any);
         resetWllamaInstance();
+        setLoadedModel(undefined);
+        setCurrRuntimeInfo(undefined);
       }
       setBusy(false);
     }
@@ -307,9 +309,6 @@ export const WllamaProvider = ({ children }: any) => {
     try {
       await verifyLocalFile(file);
       const localUrl = `local://${file.name}`;
-      if (models.some((m) => m.url === localUrl)) {
-        throw new Error('This file has already been added');
-      }
       const cachedModel = await modelManager.importFile(file);
       const userAddedModels = getUserAddedModels(cachedModels);
       const newDisplayedModel = new DisplayedModel(
@@ -318,7 +317,10 @@ export const WllamaProvider = ({ children }: any) => {
         true,
         cachedModel
       );
-      updateUserAddedModels([...userAddedModels, newDisplayedModel]);
+      updateUserAddedModels([
+        ...userAddedModels.filter((m) => m.url !== localUrl),
+        newDisplayedModel,
+      ]);
       await refreshCachedModels();
     } catch (e) {
       setBusy(false);

--- a/examples/main/src/utils/wllama.context.tsx
+++ b/examples/main/src/utils/wllama.context.tsx
@@ -8,7 +8,7 @@ import {
 import { Model, ModelManager, Wllama } from '@wllama/wllama';
 import { DEFAULT_INFERENCE_PARAMS, WLLAMA_CONFIG_PATHS } from '../config';
 import { InferenceParams, RuntimeInfo, ModelState, Screen } from './types';
-import { verifyCustomModel } from './custom-models';
+import { verifyCustomModel, verifyLocalFile } from './custom-models';
 import {
   DisplayedModel,
   getDisplayedModels,
@@ -35,6 +35,7 @@ interface WllamaContextValue {
 
   // function for managing custom user model
   addCustomModel(url: string): Promise<void>;
+  addLocalModel(file: File): Promise<void>;
   removeCustomModel(model: DisplayedModel): Promise<void>;
 
   // functions for chat completion
@@ -81,9 +82,57 @@ export const WllamaProvider = ({ children }: any) => {
   };
   useDidMount(refreshCachedModels);
 
+  useDidMount(async () => {
+    const savedLoadedModelUrl = WllamaStorage.load<string | undefined>(
+      'loaded_model',
+      undefined as any
+    );
+    if (savedLoadedModelUrl) {
+      setBusy(true);
+      try {
+        await refreshCachedModels();
+        const models = await modelManager.getModels();
+        const cachedModel = models.find((m) => m.url === savedLoadedModelUrl);
+        if (cachedModel) {
+          setLoadedModel(
+            new DisplayedModel(
+              savedLoadedModelUrl,
+              cachedModel.size,
+              savedLoadedModelUrl.startsWith('local://'),
+              cachedModel
+            ).clone({ state: ModelState.LOADING })
+          );
+          await wllamaInstance.loadModel(cachedModel, {
+            n_threads:
+              currParams.nThreads > 0 ? currParams.nThreads : undefined,
+            n_ctx: currParams.nContext,
+            n_batch: currParams.nBatch,
+          });
+          setLoadedModel(
+            new DisplayedModel(
+              savedLoadedModelUrl,
+              cachedModel.size,
+              savedLoadedModelUrl.startsWith('local://'),
+              cachedModel
+            ).clone({ state: ModelState.LOADED })
+          );
+          setCurrRuntimeInfo({
+            isMultithread: wllamaInstance.isMultithread(),
+            hasChatTemplate: !!wllamaInstance.getChatTemplate(),
+          });
+        }
+      } catch (e) {
+        console.error('Failed to auto-load model:', e);
+        WllamaStorage.save('loaded_model', undefined as any);
+        resetWllamaInstance();
+      }
+      setBusy(false);
+    }
+  });
+
   // computed variables
   const models = useMemo(() => {
-    const list = getDisplayedModels(cachedModels);
+    const list = [...getDisplayedModels(cachedModels)];
     for (const model of list) {
       model.downloadPercent = downloadingProgress[model.url] ?? -1;
       if (model.downloadPercent >= 0) {
@@ -152,10 +201,10 @@ export const WllamaProvider = ({ children }: any) => {
 
   const loadModel = async (model: DisplayedModel) => {
     if (isDownloading || loadedModel || isLoadingModel) return;
-    // make sure the model is cached
     if (!model.cachedModel) {
       throw new Error('Model is not in cache');
     }
+
     setLoadedModel(model.clone({ state: ModelState.LOADING }));
     try {
       await wllamaInstance.loadModel(model.cachedModel, {
@@ -163,6 +212,7 @@ export const WllamaProvider = ({ children }: any) => {
         n_ctx: currParams.nContext,
         n_batch: currParams.nBatch,
       });
+      WllamaStorage.save('loaded_model', model.url);
       setLoadedModel(model.clone({ state: ModelState.LOADED }));
       setCurrRuntimeInfo({
         isMultithread: wllamaInstance.isMultithread(),
@@ -170,6 +220,7 @@ export const WllamaProvider = ({ children }: any) => {
       });
     } catch (e) {
       resetWllamaInstance();
+      WllamaStorage.save('loaded_model', undefined as any);
       alert(`Failed to load model: ${(e as any).message ?? 'Unknown error'}`);
       setLoadedModel(undefined);
     }
@@ -177,8 +228,13 @@ export const WllamaProvider = ({ children }: any) => {
 
   const unloadModel = async () => {
     if (!loadedModel) return;
-    await wllamaInstance.exit();
+    try {
+      await wllamaInstance.exit();
+    } catch (e) {
+      console.warn('Error during exit:', e);
+    }
     resetWllamaInstance();
+    WllamaStorage.save('loaded_model', undefined as any);
     setLoadedModel(undefined);
     setCurrRuntimeInfo(undefined);
   };
@@ -246,9 +302,37 @@ export const WllamaProvider = ({ children }: any) => {
     setBusy(false);
   };
 
+  const addLocalModel = async (file: File) => {
+    setBusy(true);
+    try {
+      await verifyLocalFile(file);
+      const localUrl = `local://${file.name}`;
+      if (models.some((m) => m.url === localUrl)) {
+        throw new Error('This file has already been added');
+      }
+      const cachedModel = await modelManager.importFile(file);
+      const userAddedModels = getUserAddedModels(cachedModels);
+      const newDisplayedModel = new DisplayedModel(
+        localUrl,
+        file.size,
+        true,
+        cachedModel
+      );
+      updateUserAddedModels([...userAddedModels, newDisplayedModel]);
+      await refreshCachedModels();
+    } catch (e) {
+      setBusy(false);
+      throw e;
+    }
+    setBusy(false);
+  };
+
   const removeCustomModel = async (model: DisplayedModel) => {
     setBusy(true);
     if (model.isUserAdded) {
+      if (model.isLocalFile && model.cachedModel) {
+        await model.cachedModel.remove();
+      }
       const userAddedModels = getUserAddedModels(cachedModels);
       const newList = userAddedModels.filter((m) => m.url !== model.url);
       updateUserAddedModels(newList);
@@ -281,6 +365,7 @@ export const WllamaProvider = ({ children }: any) => {
         currScreen,
         getWllamaInstance: () => wllamaInstance,
         addCustomModel,
+        addLocalModel,
         removeCustomModel,
         currRuntimeInfo,
       }}

--- a/examples/main/src/utils/wllama.context.tsx
+++ b/examples/main/src/utils/wllama.context.tsx
@@ -308,17 +308,16 @@ export const WllamaProvider = ({ children }: any) => {
     setBusy(true);
     try {
       await verifyLocalFile(file);
-      const localUrl = `local://${file.name}`;
       const cachedModel = await modelManager.importFile(file);
       const userAddedModels = getUserAddedModels(cachedModels);
       const newDisplayedModel = new DisplayedModel(
-        localUrl,
+        cachedModel.url,
         file.size,
         true,
         cachedModel
       );
       updateUserAddedModels([
-        ...userAddedModels.filter((m) => m.url !== localUrl),
+        ...userAddedModels.filter((m) => m.url !== cachedModel.url),
         newDisplayedModel,
       ]);
       await refreshCachedModels();

--- a/guides/intro-v2.md
+++ b/guides/intro-v2.md
@@ -47,6 +47,19 @@ Key features of `ModelManager`:
 - Built-in model validation
 - Parallel downloads of model shards
 - Cache management with refresh and removal options
+- Importing local GGUF files into persistent browser storage
+
+You can also import a user-selected local GGUF file into cache:
+
+```typescript
+const modelManager = new ModelManager();
+const file = fileInput.files?.[0];
+
+if (file) {
+  const model = await modelManager.importFile(file);
+  await wllama.loadModel(model);
+}
+```
 
 ## Added `loadModelFromHF`
 

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -80,8 +80,53 @@ class CacheManager {
     stream: ReadableStream,
     metadata: CacheEntryMetadata
   ): Promise<void> {
-    this.writeMetadata(name, metadata); // no need await
-    return await opfsWrite(name, stream);
+    await this.writeMetadata(name, metadata);
+    const writable = await opfsWriteViaWorker(name);
+    await writable.truncate(0);
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      await writable.write(value);
+    }
+    await writable.close();
+  }
+
+  /**
+   * Write a Blob directly to cache.
+   *
+   * This is primarily used for importing user-selected local GGUF files into
+   * OPFS so they can be reused later like downloaded models.
+   */
+  async writeFileFromBlob(
+    localUrl: string,
+    blob: Blob,
+    metadata: CacheEntryMetadata
+  ): Promise<void> {
+    const name = await urlToFileName(localUrl, '');
+    const metadataFileName = PREFIX_METADATA + name;
+    const metadataBlob = new Blob([JSON.stringify(metadata)], {
+      type: 'text/plain',
+    });
+    const metadataStream = metadataBlob.stream();
+    const metadataWritable = await opfsWriteViaWorker(metadataFileName);
+    await metadataWritable.truncate(0);
+    const metadataReader = metadataStream.getReader();
+    while (true) {
+      const { done, value } = await metadataReader.read();
+      if (done) break;
+      await metadataWritable.write(value);
+    }
+    await metadataWritable.close();
+    const dataWritable = await opfsWriteViaWorker(name);
+    await dataWritable.truncate(0);
+    const dataReader = blob.stream().getReader();
+    while (true) {
+      const { done, value } = await dataReader.read();
+      if (done) break;
+      await dataWritable.write(value);
+    }
+    await dataWritable.close();
   }
 
   async download(url: string, options: DownloadOptions = {}): Promise<void> {
@@ -254,8 +299,17 @@ class CacheManager {
     name: string,
     metadata: CacheEntryMetadata
   ): Promise<void> {
+    const metadataFileName = PREFIX_METADATA + name;
     const blob = new Blob([JSON.stringify(metadata)], { type: 'text/plain' });
-    await opfsWrite(name, blob.stream(), PREFIX_METADATA);
+    const writable = await opfsWriteViaWorker(metadataFileName);
+    await writable.truncate(0);
+    const reader = blob.stream().getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      await writable.write(value);
+    }
+    await writable.close();
   }
 }
 
@@ -269,20 +323,16 @@ async function opfsWrite(
   stream: ReadableStream,
   prefix = ''
 ): Promise<void> {
-  try {
-    const fileName = await urlToFileName(key, prefix);
-    const writable = await opfsWriteViaWorker(fileName);
-    await writable.truncate(0); // clear file content
-    const reader = stream.getReader();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      await writable.write(value);
-    }
-    await writable.close();
-  } catch (e) {
-    console.error('opfsWrite', e);
+  const fileName = await urlToFileName(key, prefix);
+  const writable = await opfsWriteViaWorker(fileName);
+  await writable.truncate(0); // clear file content
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    await writable.write(value);
   }
+  await writable.close();
 }
 
 /**
@@ -361,9 +411,9 @@ async function opfsWriteViaWorker(fileName: string): Promise<{
     else if (e.data.err) pReject(e.data.err);
   };
   const workerExec = (data: {
-    open?: string;
-    value?: Uint8Array;
-    done?: boolean;
+    action: string;
+    filename?: string;
+    buf?: Uint8Array;
   }) =>
     new Promise<void>((resolve, reject) => {
       pResolve = resolve;
@@ -374,18 +424,18 @@ async function opfsWriteViaWorker(fileName: string): Promise<{
         isSafariMobile()
           ? undefined
           : {
-              transfer: data.value ? [data.value.buffer] : [],
+              transfer: data.buf ? [data.buf.buffer] : [],
             }
       );
     });
-  await workerExec({ open: fileName });
+  await workerExec({ action: 'open', filename: fileName });
   return {
     truncate: async () => {
       /* noop */
     },
-    write: (value) => workerExec({ value }),
+    write: (value) => workerExec({ action: 'write', buf: value }),
     close: async () => {
-      await workerExec({ done: true });
+      await workerExec({ action: 'close' });
       worker.terminate();
     },
   };

--- a/src/model-manager.test.ts
+++ b/src/model-manager.test.ts
@@ -209,6 +209,7 @@ test.sequential('import local gguf file into cache', async () => {
   ]);
   const file = new File([fileBytes], 'tiny-local.gguf', {
     type: 'application/octet-stream',
+    lastModified: 1710000000000,
   });
 
   let lastProgress: { loaded: number; total: number } | undefined;
@@ -216,9 +217,9 @@ test.sequential('import local gguf file into cache', async () => {
     lastProgress = progress;
   });
 
-  expect(model.url).toBe('local://tiny-local.gguf');
+  expect(model.url).toMatch(/^local:\/\/[0-9a-f]+\/tiny-local\.gguf$/);
   expect(model.size).toBe(file.size);
-  expect(model.validate()).toBe(ModelValidationStatus.VALID);
+  expect(await model.validate()).toBe(ModelValidationStatus.VALID);
   expect(lastProgress).toEqual({ loaded: file.size, total: file.size });
 
   const cachedModels = await manager.getModels();
@@ -257,7 +258,7 @@ test.sequential('importFile rejects invalid gguf magic header', async () => {
   );
 });
 
-test.sequential('importFile overwrites same-name local model with new contents', async () => {
+test.sequential('importFile keeps same-name local models distinct', async () => {
   const manager = new ModelManager();
   await manager.clear();
 
@@ -272,23 +273,30 @@ test.sequential('importFile overwrites same-name local model with new contents',
 
   const firstFile = new File([firstBytes], 'replace-me.gguf', {
     type: 'application/octet-stream',
+    lastModified: 1710000000000,
   });
   const secondFile = new File([secondBytes], 'replace-me.gguf', {
     type: 'application/octet-stream',
+    lastModified: 1710000001000,
   });
 
-  await manager.importFile(firstFile);
-  await manager.importFile(secondFile);
+  const firstModel = await manager.importFile(firstFile);
+  const secondModel = await manager.importFile(secondFile);
+
+  expect(firstModel.url).not.toBe(secondModel.url);
 
   const models = await manager.getModels();
-  expect(models.filter((m) => m.url === 'local://replace-me.gguf')).toHaveLength(
-    1
-  );
+  expect(models).toHaveLength(2);
 
-  const model = models.find((m) => m.url === 'local://replace-me.gguf');
-  expect(model).toBeDefined();
+  const firstCachedModel = models.find((m) => m.url === firstModel.url);
+  const secondCachedModel = models.find((m) => m.url === secondModel.url);
+  expect(firstCachedModel).toBeDefined();
+  expect(secondCachedModel).toBeDefined();
 
-  const [blob] = await model!.open();
-  const bytes = new Uint8Array(await blob.arrayBuffer());
-  expect(Array.from(bytes)).toEqual(Array.from(secondBytes));
+  const [firstBlob] = await firstCachedModel!.open();
+  const [secondBlob] = await secondCachedModel!.open();
+  const firstImportedBytes = new Uint8Array(await firstBlob.arrayBuffer());
+  const secondImportedBytes = new Uint8Array(await secondBlob.arrayBuffer());
+  expect(Array.from(firstImportedBytes)).toEqual(Array.from(firstBytes));
+  expect(Array.from(secondImportedBytes)).toEqual(Array.from(secondBytes));
 });

--- a/src/model-manager.test.ts
+++ b/src/model-manager.test.ts
@@ -198,3 +198,41 @@ test.sequential('clear model manager', async () => {
   await manager.clear();
   expect((await manager.getModels()).length).toBe(0);
 });
+
+test.sequential('import local gguf file into cache', async () => {
+  const manager = new ModelManager();
+  await manager.clear();
+
+  const fileBytes = new Uint8Array([
+    0x47, 0x47, 0x55, 0x46, 0x01, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+    0x20, 0x00, 0x00, 0x00,
+  ]);
+  const file = new File([fileBytes], 'tiny-local.gguf', {
+    type: 'application/octet-stream',
+  });
+
+  let lastProgress: { loaded: number; total: number } | undefined;
+  const model = await manager.importFile(file, (progress) => {
+    lastProgress = progress;
+  });
+
+  expect(model.url).toBe('local://tiny-local.gguf');
+  expect(model.size).toBe(file.size);
+  expect(model.validate()).toBe(ModelValidationStatus.VALID);
+  expect(lastProgress).toEqual({ loaded: file.size, total: file.size });
+
+  const cachedModels = await manager.getModels();
+  const cachedModel = cachedModels.find((m) => m.url === model.url);
+  expect(cachedModel).toBeDefined();
+
+  const importedAgain = await manager.importFile(file);
+  expect(importedAgain.url).toBe(model.url);
+  const cachedModelsAfterSecondImport = await manager.getModels();
+  expect(
+    cachedModelsAfterSecondImport.filter((m) => m.url === model.url)
+  ).toHaveLength(1);
+
+  const [blob] = await cachedModel!.open();
+  const importedBytes = new Uint8Array(await blob.arrayBuffer());
+  expect(Array.from(importedBytes)).toEqual(Array.from(fileBytes));
+});

--- a/src/model-manager.test.ts
+++ b/src/model-manager.test.ts
@@ -236,3 +236,59 @@ test.sequential('import local gguf file into cache', async () => {
   const importedBytes = new Uint8Array(await blob.arrayBuffer());
   expect(Array.from(importedBytes)).toEqual(Array.from(fileBytes));
 });
+
+test.sequential('importFile rejects non-gguf extension', async () => {
+  const manager = new ModelManager();
+  const file = new File(['not a gguf'], 'tiny-local.bin', {
+    type: 'application/octet-stream',
+  });
+
+  await expect(manager.importFile(file)).rejects.toThrow('must end with ".gguf"');
+});
+
+test.sequential('importFile rejects invalid gguf magic header', async () => {
+  const manager = new ModelManager();
+  const file = new File([new Uint8Array([0x00, 0x01, 0x02, 0x03])], 'bad.gguf', {
+    type: 'application/octet-stream',
+  });
+
+  await expect(manager.importFile(file)).rejects.toThrow(
+    'does not start with GGUF magic number'
+  );
+});
+
+test.sequential('importFile overwrites same-name local model with new contents', async () => {
+  const manager = new ModelManager();
+  await manager.clear();
+
+  const firstBytes = new Uint8Array([
+    0x47, 0x47, 0x55, 0x46, 0x01, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+    0x20, 0x00, 0x00, 0x00,
+  ]);
+  const secondBytes = new Uint8Array([
+    0x47, 0x47, 0x55, 0x46, 0xaa, 0xbb, 0xcc, 0xdd, 0x99, 0x88, 0x77, 0x66,
+    0x55, 0x44, 0x33, 0x22,
+  ]);
+
+  const firstFile = new File([firstBytes], 'replace-me.gguf', {
+    type: 'application/octet-stream',
+  });
+  const secondFile = new File([secondBytes], 'replace-me.gguf', {
+    type: 'application/octet-stream',
+  });
+
+  await manager.importFile(firstFile);
+  await manager.importFile(secondFile);
+
+  const models = await manager.getModels();
+  expect(models.filter((m) => m.url === 'local://replace-me.gguf')).toHaveLength(
+    1
+  );
+
+  const model = models.find((m) => m.url === 'local://replace-me.gguf');
+  expect(model).toBeDefined();
+
+  const [blob] = await model!.open();
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  expect(Array.from(bytes)).toEqual(Array.from(secondBytes));
+});

--- a/src/model-manager.ts
+++ b/src/model-manager.ts
@@ -337,17 +337,9 @@ export class ModelManager {
     file: File,
     progressCallback?: (progress: { loaded: number; total: number }) => void
   ): Promise<Model> {
-    const localUrl = `local://${file.name}`;
-    const existingModels = await this.getModels();
-    const existing = existingModels.find((m) => m.url === localUrl);
-    if (existing) {
-      const validity = existing.validate();
-      if (validity === ModelValidationStatus.VALID) {
-        progressCallback?.({ loaded: file.size, total: file.size });
-        return existing;
-      }
-    }
+    await validateLocalGgufFile(file);
 
+    const localUrl = `local://${file.name}`;
     const cacheEntry: CacheEntry = {
       name: await this.cacheManager.getNameFromURL(localUrl),
       size: file.size,
@@ -366,5 +358,29 @@ export class ModelManager {
     progressCallback?.({ loaded: file.size, total: file.size });
 
     return new Model(this, localUrl, [cacheEntry]);
+  }
+}
+
+const GGUF_MAGIC_NUMBER = new Uint8Array([0x47, 0x47, 0x55, 0x46]);
+
+async function validateLocalGgufFile(file: File): Promise<void> {
+  if (!isValidGgufFile(file.name)) {
+    throw new WllamaError(
+      `Invalid model file: ${file.name}; file name must end with ".gguf"`,
+      'download_error'
+    );
+  }
+
+  const headerBuf = await file.slice(0, GGUF_MAGIC_NUMBER.length).arrayBuffer();
+  const header = new Uint8Array(headerBuf);
+  const hasGgufMagic = GGUF_MAGIC_NUMBER.every((byte, index) => {
+    return header[index] === byte;
+  });
+
+  if (!hasGgufMagic) {
+    throw new WllamaError(
+      `Invalid model file: ${file.name}; file does not start with GGUF magic number`,
+      'download_error'
+    );
   }
 }

--- a/src/model-manager.ts
+++ b/src/model-manager.ts
@@ -321,4 +321,50 @@ export class ModelManager {
   async clear(): Promise<void> {
     await this.cacheManager.clear();
   }
+
+  /**
+   * Import a local GGUF file into the cache.
+   *
+   * The file will be stored in OPFS under a `local://` URL scheme.
+   * This allows local files to be treated the same as downloaded models,
+   * including persistence across page refreshes.
+   *
+   * @param file The File object to import
+   * @param progressCallback Optional callback for tracking import progress
+   * @returns A Model object representing the cached file
+   */
+  async importFile(
+    file: File,
+    progressCallback?: (progress: { loaded: number; total: number }) => void
+  ): Promise<Model> {
+    const localUrl = `local://${file.name}`;
+    const existingModels = await this.getModels();
+    const existing = existingModels.find((m) => m.url === localUrl);
+    if (existing) {
+      const validity = existing.validate();
+      if (validity === ModelValidationStatus.VALID) {
+        progressCallback?.({ loaded: file.size, total: file.size });
+        return existing;
+      }
+    }
+
+    const cacheEntry: CacheEntry = {
+      name: await this.cacheManager.getNameFromURL(localUrl),
+      size: file.size,
+      metadata: {
+        etag: '',
+        originalSize: file.size,
+        originalURL: localUrl,
+      },
+    };
+
+    await this.cacheManager.writeFileFromBlob(
+      localUrl,
+      file,
+      cacheEntry.metadata
+    );
+    progressCallback?.({ loaded: file.size, total: file.size });
+
+    return new Model(this, localUrl, [cacheEntry]);
+  }
 }

--- a/src/model-manager.ts
+++ b/src/model-manager.ts
@@ -339,7 +339,7 @@ export class ModelManager {
   ): Promise<Model> {
     await validateLocalGgufFile(file);
 
-    const localUrl = `local://${file.name}`;
+    const localUrl = await getLocalModelUrl(file);
     const cacheEntry: CacheEntry = {
       name: await this.cacheManager.getNameFromURL(localUrl),
       size: file.size,
@@ -362,6 +362,7 @@ export class ModelManager {
 }
 
 const GGUF_MAGIC_NUMBER = new Uint8Array([0x47, 0x47, 0x55, 0x46]);
+const LOCAL_MODEL_SAMPLE_SIZE = 64 * 1024;
 
 async function validateLocalGgufFile(file: File): Promise<void> {
   if (!isValidGgufFile(file.name)) {
@@ -383,4 +384,42 @@ async function validateLocalGgufFile(file: File): Promise<void> {
       'download_error'
     );
   }
+}
+
+async function getLocalModelUrl(file: File): Promise<string> {
+  const fingerprint = await getLocalModelFingerprint(file);
+  return `local://${fingerprint}/${encodeURIComponent(file.name)}`;
+}
+
+async function getLocalModelFingerprint(file: File): Promise<string> {
+  const sampleBuffers: Uint8Array[] = [];
+  const headSize = Math.min(LOCAL_MODEL_SAMPLE_SIZE, file.size);
+  sampleBuffers.push(new Uint8Array(await file.slice(0, headSize).arrayBuffer()));
+
+  if (file.size > headSize) {
+    const tailSize = Math.min(LOCAL_MODEL_SAMPLE_SIZE, file.size - headSize);
+    sampleBuffers.push(
+      new Uint8Array(await file.slice(file.size - tailSize).arrayBuffer())
+    );
+  }
+
+  const metadata = new TextEncoder().encode(
+    `${file.size}:${file.lastModified}:${file.name}`
+  );
+  const hashInput = concatUint8Arrays([metadata, ...sampleBuffers]);
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-1', hashInput));
+  return Array.from(digest)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function concatUint8Arrays(buffers: Uint8Array[]): Uint8Array {
+  const totalLength = buffers.reduce((sum, buffer) => sum + buffer.length, 0);
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const buffer of buffers) {
+    combined.set(buffer, offset);
+    offset += buffer.length;
+  }
+  return combined;
 }


### PR DESCRIPTION
This adds support for importing local GGUF files into cache via ModelManager.importFile().

It also updates the main example to:
- add a local file picker
- validate selected GGUF files
- persist imported local models in browser storage
- remember and reload the last loaded model after refresh

Docs were updated and a focused ModelManager test was added for local file import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import local .gguf model files into browser cache with progress reporting; imported models persist and can be auto-restored after refresh
  * Tabbed UI to add models from Hugging Face or local files; local models are labeled as "Local file"

* **Bug Fixes / Resilience**
  * Improved unload/remove flows to reliably clear persisted loaded-model state and cached local entries

* **Documentation**
  * New guides and README examples for importing and loading local GGUF files

* **Tests**
  * Added tests for import, validation, duplicate handling, and persistence behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->