### PR TITLE
fix missing image and warmup param

### DIFF
--- a/cpp/glue.hpp
+++ b/cpp/glue.hpp
@@ -534,6 +534,7 @@ struct glue_msg_load_req
   GLUE_FIELD_NULLABLE(bool, reasoning)
   GLUE_FIELD_NULLABLE(int, image_min_tokens)
   GLUE_FIELD_NULLABLE(int, image_max_tokens)
+  GLUE_FIELD_NULLABLE(bool, warmup)
 };
 
 struct glue_msg_load_res

--- a/cpp/wllama-context.h
+++ b/cpp/wllama-context.h
@@ -348,6 +348,11 @@ struct wllama_context
       }
     }
 
+    // Equivalent to llama.cpp's --no-warmup when set to false. Defaults
+    // to llama.cpp's default (true) when omitted from the request.
+    if (req.warmup.not_null())
+      params.warmup = req.warmup.value;
+
     // init threadpool
     ggml_threadpool_params_default(params.cpuparams.n_threads);
 

--- a/cpp/wllama-context.h
+++ b/cpp/wllama-context.h
@@ -347,9 +347,7 @@ struct wllama_context
         params.default_template_kwargs[keys[i]] = vals[i];
       }
     }
-
-    // Equivalent to llama.cpp's --no-warmup when set to false. Defaults
-    // to llama.cpp's default (true) when omitted from the request.
+    
     if (req.warmup.not_null())
       params.warmup = req.warmup.value;
 

--- a/src/glue/messages.ts
+++ b/src/glue/messages.ts
@@ -212,6 +212,11 @@ export const GLUE_MESSAGE_PROTOTYPES: { [name: string]: GlueMessageProto } = {
         "type": "int",
         "name": "image_max_tokens",
         "isNullable": true
+      },
+      {
+        "type": "bool",
+        "name": "warmup",
+        "isNullable": true
       }
     ]
   },
@@ -472,6 +477,7 @@ export interface GlueMsgLoadReq {
   reasoning?: boolean | undefined;
   image_min_tokens?: number | undefined;
   image_max_tokens?: number | undefined;
+  warmup?: boolean | undefined;
 }
 
 // struct glue_msg_load_res

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -38,8 +38,6 @@ export interface LoadModelParams {
   reasoning?: boolean;
   image_min_tokens?: number;
   image_max_tokens?: number;
-  // mirrors llama.cpp's --no-warmup. When false, skips the warmup decode at
-  // model load time. Defaults to llama.cpp's default (true) when omitted.
   warmup?: boolean;
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -36,6 +36,8 @@ export interface LoadModelParams {
   chat_template?: string;
   jinja?: boolean;
   reasoning?: boolean;
+  image_min_tokens?: number;
+  image_max_tokens?: number;
 }
 
 // Note: snake_case is used to match llama.cpp's naming convention

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -38,6 +38,9 @@ export interface LoadModelParams {
   reasoning?: boolean;
   image_min_tokens?: number;
   image_max_tokens?: number;
+  // mirrors llama.cpp's --no-warmup. When false, skips the warmup decode at
+  // model load time. Defaults to llama.cpp's default (true) when omitted.
+  warmup?: boolean;
 }
 
 // Note: snake_case is used to match llama.cpp's naming convention

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -568,6 +568,8 @@ export class Wllama {
       chat_template: params.chat_template,
       jinja: params.jinja,
       reasoning: params.reasoning,
+      image_min_tokens: params.image_min_tokens,
+      image_max_tokens: params.image_max_tokens,
     });
     const loadedCtxInfo: LoadedContextInfo & GlueMsgLoadRes = {
       ...loadResult,

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -570,6 +570,7 @@ export class Wllama {
       reasoning: params.reasoning,
       image_min_tokens: params.image_min_tokens,
       image_max_tokens: params.image_max_tokens,
+      warmup: params.warmup,
     });
     const loadedCtxInfo: LoadedContextInfo & GlueMsgLoadRes = {
       ...loadResult,


### PR DESCRIPTION
- **fix: add mising image min and max tokens**
- **fix: add missing warmup parameter**


Fixes [my earlier comment](https://github.com/ngxson/wllama/issues/226#issuecomment-4528865462)

I tested the image min and max tokens and they work wonderfully. Also tested the warmup is working although I needed one more commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "warmup" parameter to model loading to control initialization behavior during load.
  * Added optional image_min_tokens and image_max_tokens parameters to configure image token sizing when loading multimodal models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ngxson/wllama/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->