### PR TITLE
fix: n_ctx_checkpoints type from bool to int

### DIFF
--- a/cpp/glue.hpp
+++ b/cpp/glue.hpp
@@ -525,7 +525,7 @@ struct glue_msg_load_req
   GLUE_FIELD_NULLABLE(bool, kv_unified)
   GLUE_FIELD_NULLABLE(bool, flash_attn)
   GLUE_FIELD_NULLABLE(bool, swa_full)
-  GLUE_FIELD_NULLABLE(bool, n_ctx_checkpoints)
+  GLUE_FIELD_NULLABLE(int, n_ctx_checkpoints)
   GLUE_FIELD_NULLABLE(int, checkpoint_every_nt)
   GLUE_FIELD_NULLABLE(str, chat_template)
   GLUE_FIELD_NULLABLE(bool, jinja)

--- a/cpp/glue.hpp
+++ b/cpp/glue.hpp
@@ -21,7 +21,7 @@
 #include <functional>
 
 // increase when messages change
-#define GLUE_VERSION 1
+#define GLUE_VERSION 2
 
 #define GLUE_MAGIC 0x45554c47 // "GLUE"
 #define GLUE_PROTO_ID_LEN 8

--- a/src/glue/messages.ts
+++ b/src/glue/messages.ts
@@ -169,7 +169,7 @@ export const GLUE_MESSAGE_PROTOTYPES: { [name: string]: GlueMessageProto } = {
         "isNullable": true
       },
       {
-        "type": "bool",
+        "type": "int",
         "name": "n_ctx_checkpoints",
         "isNullable": true
       },
@@ -468,7 +468,7 @@ export interface GlueMsgLoadReq {
   kv_unified?: boolean | undefined;
   flash_attn?: boolean | undefined;
   swa_full?: boolean | undefined;
-  n_ctx_checkpoints?: boolean | undefined;
+  n_ctx_checkpoints?: number | undefined;
   checkpoint_every_nt?: number | undefined;
   chat_template?: string | undefined;
   jinja?: boolean | undefined;

--- a/src/glue/messages.ts
+++ b/src/glue/messages.ts
@@ -3,7 +3,7 @@
 
 import type { GlueMessageProto } from './glue';
 
-export const GLUE_VERSION = 1;
+export const GLUE_VERSION = 2;
 
 export const GLUE_MESSAGE_PROTOTYPES: { [name: string]: GlueMessageProto } = {
   "erro_evt": {


### PR DESCRIPTION
Spotted by claude code, verified by a human taking a look at llama.cpp's code [right there](https://github.com/ggml-org/llama.cpp/blob/6c4cbdc70b83ac054106e9de3ebc2ecaa82c4b1f/common/common.h#L596)

**Please let me know if this kind of contribution method is not welcome, I am truly grateful to wllama :)**

`common_params.n_ctx_checkpoints` is an int count in llama.cpp, not a boolean.
Encoding it as bool clamped any caller-supplied value to 0 or 1, making it impossible to request more than a single checkpoint.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Breaking Changes**
  * Wire protocol version was bumped to v2; older serialized payloads will be rejected.
  * The `n_ctx_checkpoints` parameter in load requests now accepts an integer value instead of a boolean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ngxson/wllama/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->