### PR TITLE
disable cache_idle_slots to suppress kv_unified warning

### DIFF
--- a/cpp/glue.hpp
+++ b/cpp/glue.hpp
@@ -21,7 +21,7 @@
 #include <functional>
 
 // increase when messages change
-#define GLUE_VERSION 1
+#define GLUE_VERSION 2
 
 #define GLUE_MAGIC 0x45554c47 // "GLUE"
 #define GLUE_PROTO_ID_LEN 8

--- a/cpp/glue.hpp
+++ b/cpp/glue.hpp
@@ -523,6 +523,7 @@ struct glue_msg_load_req
   GLUE_FIELD_NULLABLE(str, cache_type_k)
   GLUE_FIELD_NULLABLE(str, cache_type_v)
   GLUE_FIELD_NULLABLE(bool, kv_unified)
+  GLUE_FIELD_NULLABLE(bool, cache_idle_slots)
   GLUE_FIELD_NULLABLE(bool, flash_attn)
   GLUE_FIELD_NULLABLE(bool, swa_full)
   GLUE_FIELD_NULLABLE(bool, n_ctx_checkpoints)

--- a/cpp/wllama-context.h
+++ b/cpp/wllama-context.h
@@ -282,6 +282,8 @@ struct wllama_context
       params.n_batch = req.n_batch.value;
     if (req.n_parallel.not_null())
       params.n_parallel = req.n_parallel.value;
+    if (req.cache_idle_slots.not_null())
+      params.cache_idle_slots = req.cache_idle_slots.value;
     if (req.pooling_type.not_null())
       params.pooling_type = pooling_type_from_str(req.pooling_type.value);
     // context extending: https://github.com/ggerganov/llama.cpp/pull/2054

--- a/src/glue/messages.ts
+++ b/src/glue/messages.ts
@@ -160,6 +160,11 @@ export const GLUE_MESSAGE_PROTOTYPES: { [name: string]: GlueMessageProto } = {
       },
       {
         "type": "bool",
+        "name": "cache_idle_slots",
+        "isNullable": true
+      },
+      {
+        "type": "bool",
         "name": "flash_attn",
         "isNullable": true
       },
@@ -466,6 +471,7 @@ export interface GlueMsgLoadReq {
   cache_type_k?: string | undefined;
   cache_type_v?: string | undefined;
   kv_unified?: boolean | undefined;
+  cache_idle_slots?: boolean | undefined;
   flash_attn?: boolean | undefined;
   swa_full?: boolean | undefined;
   n_ctx_checkpoints?: boolean | undefined;

--- a/src/glue/messages.ts
+++ b/src/glue/messages.ts
@@ -3,7 +3,7 @@
 
 import type { GlueMessageProto } from './glue';
 
-export const GLUE_VERSION = 1;
+export const GLUE_VERSION = 2;
 
 export const GLUE_MESSAGE_PROTOTYPES: { [name: string]: GlueMessageProto } = {
   "erro_evt": {

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -563,6 +563,7 @@ export class Wllama {
       cache_type_v: params.cache_type_v as string,
       n_parallel: 1, // only support single sequence for now
       kv_unified: false, // TODO: support kv unified cache
+      cache_idle_slots: false, // suppress llama.cpp "--cache-idle-slots requires --kv-unified" warning until kv_unified support
       flash_attn: params.flash_attn,
       swa_full: params.swa_full,
       chat_template: params.chat_template,


### PR DESCRIPTION
Right now wllama runs a single sequence (n_parallel=1) and keeps kv_unified=false. But this causes llama.cpp's server-context.cpp to log "--cache-idle-slots requires --kv-unified, disabling" on every load in the web debug tools.

This PR forces cache_idle_slots off so the warning never fires.

**Please let me know if this kind of contribution method is not welcome**

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional cache_idle_slots parameter for model load requests.

* **Updates**
  * Serialization protocol version bumped to 2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ngxson/wllama/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->