### PR TITLE
feat: expose reasoning_budget_tokens and reasoning_budget_message in LoadModelParams

### DIFF
--- a/cpp/glue.hpp
+++ b/cpp/glue.hpp
@@ -532,6 +532,8 @@ struct glue_msg_load_req
   GLUE_FIELD_NULLABLE(arr_str, default_template_kwargs_keys)
   GLUE_FIELD_NULLABLE(arr_str, default_template_kwargs_vals)
   GLUE_FIELD_NULLABLE(bool, reasoning)
+  GLUE_FIELD_NULLABLE(int, reasoning_budget_tokens)
+  GLUE_FIELD_NULLABLE(str, reasoning_budget_message)
   GLUE_FIELD_NULLABLE(int, image_min_tokens)
   GLUE_FIELD_NULLABLE(int, image_max_tokens)
   GLUE_FIELD_NULLABLE(bool, warmup)

--- a/cpp/wllama-context.h
+++ b/cpp/wllama-context.h
@@ -334,6 +334,10 @@ struct wllama_context
         params.default_template_kwargs["enable_thinking"] = "false";
       }
     }
+    if (req.reasoning_budget_tokens.not_null())
+      params.sampling.reasoning_budget_tokens = req.reasoning_budget_tokens.value;
+    if (req.reasoning_budget_message.not_null())
+      params.sampling.reasoning_budget_message = req.reasoning_budget_message.value;
     if (req.default_template_kwargs_keys.not_null() && req.default_template_kwargs_vals.not_null())
     {
       auto &keys = req.default_template_kwargs_keys.arr;

--- a/src/glue/messages.ts
+++ b/src/glue/messages.ts
@@ -205,6 +205,16 @@ export const GLUE_MESSAGE_PROTOTYPES: { [name: string]: GlueMessageProto } = {
       },
       {
         "type": "int",
+        "name": "reasoning_budget_tokens",
+        "isNullable": true
+      },
+      {
+        "type": "str",
+        "name": "reasoning_budget_message",
+        "isNullable": true
+      },
+      {
+        "type": "int",
         "name": "image_min_tokens",
         "isNullable": true
       },
@@ -475,6 +485,8 @@ export interface GlueMsgLoadReq {
   default_template_kwargs_keys?: string[] | undefined;
   default_template_kwargs_vals?: string[] | undefined;
   reasoning?: boolean | undefined;
+  reasoning_budget_tokens?: number | undefined;
+  reasoning_budget_message?: string | undefined;
   image_min_tokens?: number | undefined;
   image_max_tokens?: number | undefined;
   warmup?: boolean | undefined;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -36,6 +36,8 @@ export interface LoadModelParams {
   chat_template?: string;
   jinja?: boolean;
   reasoning?: boolean;
+  reasoning_budget_tokens?: number;
+  reasoning_budget_message?: string;
   image_min_tokens?: number;
   image_max_tokens?: number;
   warmup?: boolean;

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -568,6 +568,8 @@ export class Wllama {
       chat_template: params.chat_template,
       jinja: params.jinja,
       reasoning: params.reasoning,
+      reasoning_budget_tokens: params.reasoning_budget_tokens,
+      reasoning_budget_message: params.reasoning_budget_message,
       image_min_tokens: params.image_min_tokens,
       image_max_tokens: params.image_max_tokens,
       warmup: params.warmup,


### PR DESCRIPTION
Hi, it's me again :)


I'm making this PR to expose two parameters that I think are extremely useful. My use case involves using tiny models to do tiny tasks and I can't afford to have them think for an unpredictable amount of time. Hence I wanted to use llamacpp server's budget feature.

The problem is, those are actually buggy in llamacpp. I ran into those issues in the past when using llamacpp and now I feel like I have a sufficently good understanding of the small issue to make a PR on llamacpp.

Regardless, it's also good to expose those parameters to wllama so here's this PR too.

I compiled llamacpp and wllama and it worked amazingly : with the few recent features I'm now able to carefully alter the thinking time and amount of image tokens to still get reliable results. Wllama is doing invaluable work for my use case (I'll tell you all about it when I'm able to push it to github, few weeks from now).

Let me know if there's anything I can do to make this accepted and thank you so much for wllama.

---

Here's Claude Code's prose about it:

llama.cpp's --reasoning-budget and --reasoning-budget-message CLI flags populate params.sampling.reasoning_budget_tokens and
params.sampling.reasoning_budget_message respectively. These then flow into server_context's chat_params at load time
(tools/server/server-context.cpp), which oaicompat_chat_params_parse reads as opt for every completion (tools/server/server-common.cpp).

Surfacing both as load-time wllama params lets in-process callers (no CLI, no server) cap thinking-token spend and customize the budget-exhausted message without patching llama.cpp.

The per-request body field thinking_budget_tokens already worked (oaicompat falls back to it when opt.reasoning_budget == -1), but nothing in the body could set the budget message because oaicompat sets it unconditionally from opt. Setting opt at load fixes both.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now configure reasoning budget parameters when loading models, specifying token limits and custom budget messages to control inference behavior during model initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ngxson/wllama/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->