### PR TITLE
add createRerank() API

### DIFF
--- a/cpp/glue.hpp
+++ b/cpp/glue.hpp
@@ -620,6 +620,20 @@ struct glue_msg_embedding_res
 
 /////////
 
+struct glue_msg_rerank_req
+{
+  GLUE_HANDLER("rrnk_req")
+  GLUE_FIELD(str, data_json)
+};
+
+struct glue_msg_rerank_res
+{
+  GLUE_HANDLER("rrnk_res")
+  GLUE_FIELD(bool, success)
+};
+
+/////////
+
 struct glue_msg_get_result_req
 {
   GLUE_HANDLER("gres_req")

--- a/cpp/wllama-context.h
+++ b/cpp/wllama-context.h
@@ -644,6 +644,37 @@ struct wllama_context
     return res;
   }
 
+  glue_msg_rerank_res action_rerank(const char *req_raw)
+  {
+    PARSE_REQ(glue_msg_rerank_req);
+    glue_msg_rerank_res res;
+
+    json body = json::parse(req.data_json.value);
+    if (!body.contains("query") || !body.at("query").is_string())
+    {
+      throw app_exception("\"query\" must be a string");
+    }
+    if (!body.contains("document") || !body.at("document").is_string())
+    {
+      throw app_exception("\"document\" must be a string");
+    }
+    std::string query = body.at("query");
+    std::string document = body.at("document");
+
+    rd = std::make_unique<server_response_reader>(ctx_server.get_response_reader());
+    last_error = "";
+
+    auto tokens = format_prompt_rerank(model, vocab, nullptr, query, document);
+    server_task task = server_task(SERVER_TASK_TYPE_RERANK);
+    task.id = rd->get_new_id();
+    task.index = 0;
+    task.tokens = std::move(tokens);
+    rd->post_task(std::move(task));
+
+    res.success.value = true;
+    return res;
+  }
+
   glue_msg_get_result_res action_get_result(const char *req_raw)
   {
     PARSE_REQ(glue_msg_get_result_req);
@@ -655,9 +686,9 @@ struct wllama_context
     json data_json;
     if (result)
     {
-      auto *res = dynamic_cast<server_task_result_embd *>(result.get());
-      if (res)
+      if (auto *embd = dynamic_cast<server_task_result_embd *>(result.get()))
       {
+        (void)embd;
         // special handling for embeddings OAI-compat
         json body = {{"model", meta->model_name}};
         json responses = json::array();
@@ -665,9 +696,16 @@ struct wllama_context
         // TODO: support base64 output
         data_json = format_embeddings_response_oaicompat(body, meta->model_name, responses, false);
       }
+      else if (auto *rerank = dynamic_cast<server_task_result_rerank *>(result.get()))
+      {
+        data_json = json{
+            {"score", rerank->score},
+            {"tokens_evaluated", rerank->n_tokens},
+        };
+      }
       else
       {
-        // otherwise, it should be a completion result, nothing special to do
+        // completion result
         data_json = result->to_json();
       }
     }

--- a/cpp/wllama.cpp
+++ b/cpp/wllama.cpp
@@ -112,6 +112,7 @@ extern "C" const char *wllama_action(const char *name, const char *req_raw)
     WLLAMA_ACTION(load)
     WLLAMA_ACTION(completion)
     WLLAMA_ACTION(embedding)
+    WLLAMA_ACTION(rerank)
     WLLAMA_ACTION(get_result)
 
     else

--- a/src/glue/messages.ts
+++ b/src/glue/messages.ts
@@ -515,6 +515,30 @@ export const GLUE_MESSAGE_PROTOTYPES: { [name: string]: GlueMessageProto } = {
       }
     ]
   },
+  "rrnk_req": {
+    "name": "rrnk_req",
+    "structName": "glue_msg_rerank_req",
+    "className": "GlueMsgRerankReq",
+    "fields": [
+      {
+        "type": "str",
+        "name": "data_json",
+        "isNullable": false
+      }
+    ]
+  },
+  "rrnk_res": {
+    "name": "rrnk_res",
+    "structName": "glue_msg_rerank_res",
+    "className": "GlueMsgRerankRes",
+    "fields": [
+      {
+        "type": "bool",
+        "name": "success",
+        "isNullable": false
+      }
+    ]
+  },
   "gres_req": {
     "name": "gres_req",
     "structName": "glue_msg_get_result_req",
@@ -677,6 +701,18 @@ export interface GlueMsgEmbeddingRes {
   success: boolean;
 }
 
+// struct glue_msg_rerank_req
+export interface GlueMsgRerankReq {
+  _name: "rrnk_req";
+  data_json: string;
+}
+
+// struct glue_msg_rerank_res
+export interface GlueMsgRerankRes {
+  _name: "rrnk_res";
+  success: boolean;
+}
+
 // struct glue_msg_get_result_req
 export interface GlueMsgGetResultReq {
   _name: "gres_req";
@@ -692,4 +728,4 @@ export interface GlueMsgGetResultRes {
 }
 
 
-export type GlueMsg = GlueMsgError | GlueMsgLoadReq | GlueMsgLoadRes | GlueMsgCompletionReq | GlueMsgCompletionRes | GlueMsgEmbeddingReq | GlueMsgEmbeddingRes | GlueMsgGetResultReq | GlueMsgGetResultRes;
+export type GlueMsg = GlueMsgError | GlueMsgLoadReq | GlueMsgLoadRes | GlueMsgCompletionReq | GlueMsgCompletionRes | GlueMsgEmbeddingReq | GlueMsgEmbeddingRes | GlueMsgRerankReq | GlueMsgRerankRes | GlueMsgGetResultReq | GlueMsgGetResultRes;

--- a/src/types/oai-compat.ts
+++ b/src/types/oai-compat.ts
@@ -308,3 +308,28 @@ export interface CreateEmbeddingResponse {
   model: string;
   usage: EmbeddingUsage;
 }
+
+// Reranking (NOT official OAI-compat, but is a commonly-used API schema)
+
+export interface RerankParams {
+  query: string;
+  documents: string[];
+  top_n?: number;
+}
+
+export interface RerankResult {
+  index: number;
+  relevance_score: number;
+}
+
+export interface RerankUsage {
+  prompt_tokens: number;
+  total_tokens: number;
+}
+
+export interface RerankResponse {
+  model: string;
+  object: 'list';
+  usage: RerankUsage;
+  results: RerankResult[];
+}

--- a/src/wllama.test.ts
+++ b/src/wllama.test.ts
@@ -20,6 +20,9 @@ const SPLIT_MODEL =
 
 const EMBD_MODEL = TINY_MODEL; // for better speed
 
+const RERANK_MODEL =
+  'https://huggingface.co/ggml-org/models/resolve/main/jina-reranker-v1-tiny-en/ggml-model-f16.gguf';
+
 test.sequential('loads single model file', async () => {
   const wllama = createWllama();
 
@@ -195,6 +198,46 @@ test.sequential('generates embeddings', async () => {
   const cosineSim = dot / (norm1 * norm2);
   expect(cosineSim).toBeGreaterThan(1 - 0.05);
   expect(cosineSim).toBeLessThan(1);
+
+  await wllama.exit();
+});
+
+test.sequential('reranks documents', async () => {
+  const wllama = createWllama();
+
+  await wllama.loadModelFromUrl(RERANK_MODEL, {
+    embeddings: true,
+    pooling_type: 'rank',
+  });
+
+  expect(wllama.isModelLoaded()).toBe(true);
+
+  const query = 'What is machine learning?';
+  const documents = [
+    'Machine learning is a branch of artificial intelligence.',
+    'The weather today is sunny and warm.',
+    'Neural networks are used in deep learning.',
+  ];
+
+  const res = await wllama.createRerank({ query, documents });
+
+  expect(res).toBeDefined();
+  expect(res.results).toHaveLength(documents.length);
+  for (const r of res.results) {
+    expect(typeof r.index).toBe('number');
+    expect(typeof r.relevance_score).toBe('number');
+  }
+
+  // results should be sorted highest score first
+  for (let i = 0; i < res.results.length - 1; i++) {
+    expect(res.results[i].relevance_score).toBeGreaterThanOrEqual(
+      res.results[i + 1].relevance_score
+    );
+  }
+
+  // the most relevant documents should outscore the other
+  const weatherIdx = res.results.findIndex((r) => r.index === 1);
+  expect(weatherIdx).toBeGreaterThan(0);
 
   await wllama.exit();
 });

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -18,6 +18,7 @@ import { ModelManager, Model, type ModelSource } from './model-manager';
 import type {
   GlueMsgCompletionRes,
   GlueMsgEmbeddingRes,
+  GlueMsgRerankRes,
   GlueMsgGetResultRes,
   GlueMsgLoadRes,
 } from './glue/messages';
@@ -37,6 +38,8 @@ import type {
   RawCompletionChunk,
   RawCompletionParams,
   RawCompletionResponse,
+  RerankParams,
+  RerankResponse,
 } from './types/oai-compat';
 import { LogLevel } from './types/types';
 import { getHFModelSource, type HuggingFaceParams } from './huggingface';
@@ -676,6 +679,52 @@ export class Wllama {
   }
 
   /**
+   * Rerank a list of documents against a query.
+   * Requires the model to be loaded with embeddings: true and pooling_type: 'rank'.
+   * @param options Reranking options (query, documents, top_n)
+   * @returns Reranking response with relevance scores sorted highest first
+   */
+  async createRerank(options: RerankParams): Promise<RerankResponse> {
+    this.checkModelLoaded();
+
+    const top_n = options.top_n ?? options.documents.length;
+    let totalTokens = 0;
+    const rawResults: Array<{ index: number; score: number }> = [];
+
+    for (let i = 0; i < options.documents.length; i++) {
+      const result = await this.proxy.wllamaAction<GlueMsgRerankRes>('rerank', {
+        _name: 'rrnk_req',
+        data_json: JSON.stringify({
+          query: options.query,
+          document: options.documents[i],
+        }),
+      });
+
+      if (!result.success) {
+        throw new WllamaError(
+          'Model failed to start reranking',
+          'inference_error'
+        );
+      }
+
+      const { score, tokens_evaluated } = await this.getRerankResult();
+      totalTokens += tokens_evaluated;
+      rawResults.push({ index: i, score });
+    }
+
+    rawResults.sort((a, b) => b.score - a.score);
+    return {
+      model: this.getModelMetadata().meta['general.name'] ?? '',
+      object: 'list',
+      usage: { prompt_tokens: totalTokens, total_tokens: totalTokens },
+      results: rawResults.slice(0, top_n).map(({ index, score }) => ({
+        index,
+        relevance_score: score,
+      })),
+    };
+  }
+
+  /**
    * Make chat completion for a given chat messages.
    * @param options OAI-compatible chat completion options
    * @returns OAI-compatible chat completion response (only the final result when stream=false) or an async iterator of completion chunks (when stream=true)
@@ -881,6 +930,34 @@ export class Wllama {
       },
       files,
     };
+  }
+
+  private async getRerankResult(): Promise<{
+    score: number;
+    tokens_evaluated: number;
+  }> {
+    while (true) {
+      const chunk = await this.proxy.wllamaAction<GlueMsgGetResultRes>(
+        'get_result',
+        { _name: 'gres_req' }
+      );
+
+      const jsonString = chunk.data_json;
+      if (jsonString && jsonString.length > 0) {
+        if (chunk.is_error) {
+          const jsonData = this.jsonDecode(jsonString);
+          throw new WllamaError(
+            jsonData.message || 'Unknown reranking error',
+            'inference_error'
+          );
+        }
+        return this.jsonDecode(jsonString);
+      }
+
+      if (!chunk.has_more) break;
+    }
+
+    throw new WllamaError('No reranking result received', 'inference_error');
   }
 
   private async getResponse(options: StreamParams<any>, isStream: boolean) {

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -161,7 +161,8 @@ export class Wllama {
   private pathConfig: AssetsPathConfig;
   private useMultiThread: boolean = false;
   private nbThreads: number = 1;
-  // private useEmbeddings: boolean = false;
+  private useEmbeddings: boolean = false;
+  private useRerank: boolean = false;
   // available when loaded
   private loadedContextInfo: LoadedContextInfo = null as any;
   private seed: number | undefined = undefined;
@@ -615,7 +616,8 @@ export class Wllama {
     this.bosToken = loadedCtxInfo.token_bos;
     this.eosToken = loadedCtxInfo.token_eos;
     this.eotToken = loadedCtxInfo.token_eot;
-    // this.useEmbeddings = !!params.embeddings;
+    this.useEmbeddings = !!params.embeddings;
+    this.useRerank = params.pooling_type == 'rank';
     this.metadata = {
       hparams: {
         nVocab: loadedCtxInfo.n_vocab,
@@ -659,6 +661,12 @@ export class Wllama {
   ): Promise<CreateEmbeddingResponse> {
     this.checkModelLoaded();
 
+    if (!this.useEmbeddings) {
+      throw new WllamaError(
+        'Embeddings is not enabled. Please set it via LoadModelParams.embeddings'
+      );
+    }
+
     const result = await this.proxy.wllamaAction<GlueMsgEmbeddingRes>(
       'embedding',
       {
@@ -686,6 +694,12 @@ export class Wllama {
    */
   async createRerank(options: RerankParams): Promise<RerankResponse> {
     this.checkModelLoaded();
+
+    if (!this.useEmbeddings || !this.useRerank) {
+      throw new WllamaError(
+        'Rerank is not enabled. Please set it via LoadModelParams: embeddings = true and pooling_type = rank'
+      );
+    }
 
     const top_n = options.top_n ?? options.documents.length;
     let totalTokens = 0;


### PR DESCRIPTION
Fix https://github.com/ngxson/wllama/issues/235

Example code:

```ts
  await wllama.loadModelFromUrl(RERANK_MODEL, {
    embeddings: true,
    pooling_type: 'rank',
  });

  const query = 'What is machine learning?';
  const documents = [
    'Machine learning is a branch of artificial intelligence.',
    'The weather today is sunny and warm.',
    'Neural networks are used in deep learning.',
  ];

  const res = await wllama.createRerank({ query, documents });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document reranking capability to score and rank documents by relevance to a query, with automatic sorting by relevance score
  * Embeddings support now requires explicit model loading configuration to ensure intentional usage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ngxson/wllama/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->