### PR TITLE
Add support for Cross-Origin Storage as a progressive enhancement

### DIFF
--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -1,6 +1,13 @@
 import type { DownloadProgressCallback } from './model-manager';
 import { createWorker, isSafariMobile } from './utils';
 import { OPFS_UTILS_WORKER_CODE } from './workers-code/generated';
+import {
+  isCrossOriginStorageAvailable,
+  resolveUrlHash,
+  setUrlHash,
+  tryReadFromCOS,
+  writeToCosByHash,
+} from './cross-origin-storage';
 
 const PREFIX_METADATA = '__metadata__';
 
@@ -59,6 +66,11 @@ export interface CacheEntryMetadata {
    * URL to mmproj file, if exists
    */
   mmprojURL?: string | undefined;
+  /**
+   * SHA-256 content hash, used as the key for Cross-Origin Storage.
+   * Present only when the file was downloaded or served via COS.
+   */
+  sha256?: string | undefined;
 }
 
 /**
@@ -93,6 +105,42 @@ export class CacheManager {
   }
 
   async download(url: string, options: DownloadOptions = {}): Promise<void> {
+    if (isCrossOriginStorageAvailable() && !options.signal?.aborted) {
+      const hash = await resolveUrlHash(url);
+      if (hash) {
+        const cosBlob = await tryReadFromCOS(hash);
+        if (cosBlob) {
+          // File already in COS – record metadata only.
+          const metadata: CacheEntryMetadata = {
+            etag: POLYFILL_ETAG,
+            originalSize: cosBlob.size,
+            originalURL: url,
+            sha256: hash,
+            ...(options.metadataAdditional ?? {}),
+          };
+          await this.writeMetadata(url, metadata);
+          options.progressCallback?.({
+            loaded: cosBlob.size,
+            total: cosBlob.size,
+          });
+          return;
+        }
+      }
+
+      // File not in COS (or hash unknown for non-HF URLs) — download directly
+      // into COS, computing the SHA-256 on-the-fly when needed.  No OPFS data
+      // is written on this path.
+      try {
+        await this.downloadToCOS(url, hash, options);
+        return;
+      } catch (e) {
+        if (options.signal?.aborted) throw e;
+        console.warn('[wllama] COS download failed, falling back to OPFS:', e);
+        // Fall through to the OPFS worker path below.
+      }
+    }
+
+    // OPFS fallback: COS unavailable or downloadToCOS failed.
     const worker = createWorker(OPFS_UTILS_WORKER_CODE);
     let aborted = false;
     if (options.signal) {
@@ -118,6 +166,7 @@ export class CacheManager {
       worker.onmessage = (e: MessageEvent<any>) => {
         if (e.data.ok) {
           worker.terminate();
+          void this.writeToCosBg(url);
           resolve();
         } else if (e.data.err) {
           worker.terminate();
@@ -126,12 +175,122 @@ export class CacheManager {
           const progress: { loaded: number; total: number } = e.data.progress;
           options.progressCallback?.(progress);
         } else {
-          // should never happen
           reject(new Error('Unknown message from worker'));
           console.error('Unknown message from worker', e.data);
         }
       };
     });
+  }
+
+  /**
+   * Download a file from the network directly into Cross-Origin Storage
+   * without writing any data to OPFS.  On success only a tiny metadata JSON
+   * is written to OPFS.
+   *
+   * When `hash` is supplied (HF LFS pointer was available) the chunks are
+   * written directly to the COS writable one-by-one — no Blob assembly.
+   * When `hash` is null (non-HF URL) the chunks are first concatenated into
+   * a single buffer so SHA-256 can be computed, then that buffer is written.
+   * Either way the data never touches OPFS.
+   */
+  private async downloadToCOS(
+    url: string,
+    hash: string | null,
+    options: DownloadOptions
+  ): Promise<void> {
+    const response = await fetch(url, {
+      headers: options.headers,
+      signal: options.signal,
+    });
+    if (!response.ok || !response.body) {
+      throw new Error(`Network error: ${response.status} ${response.statusText}`);
+    }
+
+    const total = Number(response.headers.get('content-length') || '0');
+    let loaded = 0;
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      loaded += value.byteLength;
+      options.progressCallback?.({ loaded, total });
+    }
+
+    // For unknown-hash URLs: assemble a contiguous buffer and compute SHA-256.
+    let writeBlob: Blob;
+    if (!hash) {
+      const combined = new Uint8Array(loaded);
+      let off = 0;
+      for (const c of chunks) { combined.set(c, off); off += c.byteLength; }
+      chunks.length = 0; // release individual chunks before hashing
+      const hashBuf = await crypto.subtle.digest('SHA-256', combined.buffer);
+      hash = Array.from(new Uint8Array(hashBuf))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      await setUrlHash(url, hash);
+      writeBlob = new Blob([combined]);
+    } else {
+      // Blob constructor accepts Uint8Array[] as BlobPart[].
+      writeBlob = new Blob(chunks as any[]);
+    }
+
+    const [handle] = await navigator.crossOriginStorage.requestFileHandles(
+      [{ algorithm: 'SHA-256', value: hash }],
+      { create: true }
+    );
+    const writable = await (handle as any).createWritable();
+    await writable.write(writeBlob);
+    await writable.close();
+
+    const metadata: CacheEntryMetadata = {
+      etag: POLYFILL_ETAG,
+      originalSize: loaded,
+      originalURL: url,
+      sha256: hash,
+      ...(options.metadataAdditional ?? {}),
+    };
+    await this.writeMetadata(url, metadata);
+  }
+
+  /**
+   * Background task: write a file from OPFS to Cross-Origin Storage after a
+   * successful network download.  Errors are swallowed so a COS failure never
+   * surfaces to the caller.
+   *
+   * Hash strategy:
+   * 1. Use the hash already resolved by `resolveUrlHash` (e.g. from the LFS
+   *    pointer fetch that happened in the COS pre-check above).
+   * 2. For non-HF URLs where no LFS hash exists, skip COS – computing SHA-256
+   *    of a multi-GB model file in the browser main thread is impractical.
+   */
+  private async writeToCosBg(url: string): Promise<void> {
+    if (!isCrossOriginStorageAvailable()) return;
+    try {
+      const hash = await resolveUrlHash(url);
+      if (!hash) return;
+
+      const filename = await urlToFileName(url, '');
+      const blob = await opfsOpen(filename);
+      if (!blob) return;
+
+      await writeToCosByHash(blob, hash);
+
+      // COS write succeeded — update metadata with sha256 and persist the hash.
+      // We intentionally do NOT remove the OPFS data file here: the Worker may
+      // already hold a File handle to it and a concurrent removeEntry() would
+      // cause a NotFoundError mid-read.  The OPFS data will be cleaned up on
+      // the next clear() or deleteMany() call.
+      const meta = await this.getMetadata(url);
+      if (meta) {
+        await this.writeMetadata(url, { ...meta, sha256: hash });
+      }
+      await setUrlHash(url, hash);
+    } catch {
+      // Non-fatal – if COS write or cleanup fails, the file stays in OPFS.
+    }
   }
 
   /**
@@ -141,7 +300,124 @@ export class CacheManager {
    * @returns Blob, or null if file does not exist
    */
   async open(nameOrURL: string): Promise<Blob | null> {
-    return await opfsOpen(nameOrURL);
+    const fromOpfs = await opfsOpen(nameOrURL);
+    if (fromOpfs) return fromOpfs;
+    // COS fallback: if the data file is absent but the metadata records a
+    // sha256, serve the blob directly from Cross-Origin Storage.
+    // The metadata file is stored as PREFIX_METADATA + OPFS data filename.
+    if (isCrossOriginStorageAvailable()) {
+      const metaFile = await opfsOpen(PREFIX_METADATA + nameOrURL);
+      if (metaFile) {
+        try {
+          const meta: CacheEntryMetadata = await new Response(
+            metaFile.stream()
+          ).json();
+          if (meta.sha256) {
+            const cosBlob = await tryReadFromCOS(meta.sha256);
+            if (cosBlob) return cosBlob;
+            // COS resource was evicted — remove stale metadata so the next
+            // validate() returns INVALID and triggers a fresh download.
+            try {
+              const cacheDir = await getCacheDir();
+              await cacheDir.removeEntry(PREFIX_METADATA + nameOrURL);
+            } catch {}
+          }
+        } catch {}
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Check whether a file is available in Cross-Origin Storage without downloading it.
+   *
+   * Resolves the SHA-256 hash for the URL (via the HF Git LFS pointer file or a
+   * previously-cached hash entry) and queries `navigator.crossOriginStorage`.
+   *
+   * Returns the `Blob` if found in COS, `null` if the API is unavailable, the
+   * file is not cached cross-origin, or the hash cannot be determined.
+   *
+   * Callers can use the returned size to calculate total download size without
+   * making a HEAD request to the origin server.
+   */
+  async checkCOS(url: string): Promise<Blob | null> {
+    if (!isCrossOriginStorageAvailable()) return null;
+    const hash = await resolveUrlHash(url);
+    if (!hash) return null;
+    return tryReadFromCOS(hash);
+  }
+
+  /**
+   * Resolve a WASM URL through Cross-Origin Storage, avoiding a network
+   * round-trip when the binary is already cached cross-origin.
+   *
+   * Strategy:
+   * 1. If COS is unavailable, return the original URL unchanged.
+   * 2. If the SHA-256 hash is already in the hash cache (from a previous
+   *    load), attempt a COS lookup. On hit, return a `blob:` object URL
+   *    so the Worker never touches the network.
+   * 3. On COS miss, or when no hash is cached yet, fetch the WASM
+   *    normally, compute its SHA-256, write it to COS in the background,
+   *    and return a `blob:` object URL so the caller skips a second fetch.
+   * 4. On any error, return the original URL as a safe fallback.
+   *
+   * WASM files have no HF LFS pointer, so the hash is computed from
+   * content on first load and then persisted in the hash cache. WASM
+   * files are small enough (a few MB) that buffering them is fine.
+   *
+   * Note: the returned `blob:` URL is never explicitly revoked; it lives
+   * until the page is unloaded, consistent with other blob URLs in wllama.
+   */
+  async resolveWasmUrl(wasmUrl: string): Promise<string> {
+    if (!isCrossOriginStorageAvailable()) return wasmUrl;
+
+    // COS path is non-fatal: any failure falls through to the network fetch.
+    let hash: string | null = null;
+    try {
+      hash = await resolveUrlHash(wasmUrl);
+      if (hash) {
+        const cosBlob = await tryReadFromCOS(hash);
+        if (cosBlob) {
+          // Re-wrap to guarantee the correct MIME type for
+          // WebAssembly.instantiateStreaming() in the Worker.
+          const blob =
+            cosBlob.type === 'application/wasm'
+              ? cosBlob
+              : new Blob([cosBlob], { type: 'application/wasm' });
+          return URL.createObjectURL(blob);
+        }
+      }
+    } catch {
+      hash = null;
+    }
+
+    // COS miss — fetch from the network.
+    // This is intentionally outside the try/catch: a 404 or network error
+    // here means the WASM is genuinely unavailable.  Returning wasmUrl as a
+    // fallback would only cause the Worker to make the same failing request
+    // and crash with a cryptic "expected magic word" error.
+    const response = await fetch(wasmUrl);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch WASM (${response.status} ${response.statusText}): ${wasmUrl}`
+      );
+    }
+    const buf = await response.arrayBuffer();
+
+    if (!hash) {
+      // Compute and persist the hash so future loads can skip this fetch.
+      const hashBuf = await crypto.subtle.digest('SHA-256', buf);
+      hash = Array.from(new Uint8Array(hashBuf))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      await setUrlHash(wasmUrl, hash);
+    }
+
+    // Write to COS in the background; return a blob: URL from the
+    // already-fetched buffer so the Worker doesn't fetch it again.
+    const blob = new Blob([buf], { type: 'application/wasm' });
+    void writeToCosByHash(blob, hash);
+    return URL.createObjectURL(blob);
   }
 
   /**
@@ -187,35 +463,37 @@ export class CacheManager {
    */
   async list(): Promise<CacheEntry[]> {
     const cacheDir = await getCacheDir();
-    const result: CacheEntry[] = [];
     const metadataMap: Record<string, CacheEntryMetadata> = {};
+    const dataSizeMap: Record<string, number> = {};
     // @ts-ignore
-    for await (let [name, handler] of cacheDir.entries()) {
-      if (handler.kind === 'file' && name.startsWith(PREFIX_METADATA)) {
-        const stream = (
-          await (handler as FileSystemFileHandle).getFile()
-        ).stream();
-        const meta = await new Response(stream).json().catch((_) => null);
-        metadataMap[name.replace(PREFIX_METADATA, '')] = meta;
+    for await (const [name, handler] of cacheDir.entries()) {
+      if (handler.kind !== 'file') continue;
+      const file = await (handler as FileSystemFileHandle).getFile();
+      if (name.startsWith(PREFIX_METADATA)) {
+        const meta = await new Response(file.stream()).json().catch(() => null);
+        if (meta) metadataMap[name.slice(PREFIX_METADATA.length)] = meta;
+      } else {
+        dataSizeMap[name] = file.size;
       }
     }
-    // @ts-ignore
-    for await (let [name, handler] of cacheDir.entries()) {
-      if (handler.kind === 'file' && !name.startsWith(PREFIX_METADATA)) {
-        result.push({
-          name,
-          size: await (handler as FileSystemFileHandle)
-            .getFile()
-            .then((f) => f.size),
-          metadata: metadataMap[name] || {
-            // try to polyfill for old versions
-            originalSize: (await (handler as FileSystemFileHandle).getFile())
-              .size,
-            originalURL: '',
-            etag: '',
-          },
-        });
-      }
+    const result: CacheEntry[] = [];
+    const allNames = new Set([
+      ...Object.keys(metadataMap),
+      ...Object.keys(dataSizeMap),
+    ]);
+    for (const name of allNames) {
+      const meta = metadataMap[name];
+      const opfsSize = dataSizeMap[name];
+      result.push({
+        name,
+        // COS-backed entries have no OPFS data file; use the recorded size.
+        size: opfsSize ?? meta?.originalSize ?? 0,
+        metadata: meta ?? {
+          etag: POLYFILL_ETAG,
+          originalSize: opfsSize ?? 0,
+          originalURL: '',
+        },
+      });
     }
     return result;
   }
@@ -249,7 +527,13 @@ export class CacheManager {
     const list = await this.list();
     for (const item of list) {
       if (predicate(item)) {
-        cacheDir.removeEntry(item.name);
+        // Data file may be absent for COS-backed entries; swallow the error.
+        try {
+          await cacheDir.removeEntry(item.name);
+        } catch {}
+        try {
+          await cacheDir.removeEntry(PREFIX_METADATA + item.name);
+        } catch {}
       }
     }
   }
@@ -293,6 +577,7 @@ async function opfsWrite(
     console.error('opfsWrite', e);
   }
 }
+
 
 /**
  * Opens a file in OPFS for reading
@@ -369,32 +654,29 @@ async function opfsWriteViaWorker(fileName: string): Promise<{
     if (e.data.ok) pResolve(null);
     else if (e.data.err) pReject(e.data.err);
   };
-  const workerExec = (data: {
-    open?: string;
-    value?: Uint8Array;
-    done?: boolean;
-  }) =>
+  const workerExec = (
+    data: Record<string, unknown>,
+    transferBuf?: ArrayBuffer
+  ) =>
     new Promise<void>((resolve, reject) => {
       pResolve = resolve;
       pReject = reject;
       // TODO @ngxson : Safari mobile doesn't support transferable ArrayBuffer
       worker.postMessage(
         data,
-        isSafariMobile()
+        isSafariMobile() || !transferBuf
           ? undefined
-          : {
-              transfer: data.value ? [data.value.buffer] : [],
-            }
+          : { transfer: [transferBuf] }
       );
     });
-  await workerExec({ open: fileName });
+  await workerExec({ action: 'open', filename: fileName });
   return {
     truncate: async () => {
       /* noop */
     },
-    write: (value) => workerExec({ value }),
+    write: (value) => workerExec({ action: 'write', buf: value }, value.buffer),
     close: async () => {
-      await workerExec({ done: true });
+      await workerExec({ action: 'close' });
       worker.terminate();
     },
   };

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -199,8 +199,8 @@ export class CacheManager {
     options: DownloadOptions
   ): Promise<void> {
     const response = await fetch(url, {
-      headers: options.headers,
-      signal: options.signal,
+      ...(options.headers !== undefined && { headers: options.headers }),
+      ...(options.signal !== undefined && { signal: options.signal }),
     });
     if (!response.ok || !response.body) {
       throw new Error(`Network error: ${response.status} ${response.statusText}`);

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -7,6 +7,8 @@ import {
   setUrlHash,
   tryReadFromCOS,
   writeToCosByHash,
+  getWasmCacheEntry,
+  setWasmCacheEntry,
 } from './cross-origin-storage';
 
 const PREFIX_METADATA = '__metadata__';
@@ -371,31 +373,52 @@ export class CacheManager {
   async resolveWasmUrl(wasmUrl: string): Promise<string> {
     if (!isCrossOriginStorageAvailable()) return wasmUrl;
 
-    // COS path is non-fatal: any failure falls through to the network fetch.
-    let hash: string | null = null;
+    // Try to validate the cached entry with a conditional GET, then serve
+    // from COS if the content hasn't changed.  All failures are non-fatal and
+    // fall through to an unconditional network fetch.
     try {
-      hash = await resolveUrlHash(wasmUrl);
-      if (hash) {
-        const cosBlob = await tryReadFromCOS(hash);
-        if (cosBlob) {
-          // Re-wrap to guarantee the correct MIME type for
-          // WebAssembly.instantiateStreaming() in the Worker.
-          const blob =
-            cosBlob.type === 'application/wasm'
-              ? cosBlob
-              : new Blob([cosBlob], { type: 'application/wasm' });
+      const entry = await getWasmCacheEntry(wasmUrl);
+      if (entry?.etag || entry?.lastModified) {
+        const headers: Record<string, string> = {};
+        if (entry.etag) headers['If-None-Match'] = entry.etag;
+        else if (entry.lastModified) headers['If-Modified-Since'] = entry.lastModified;
+
+        const resp = await fetch(wasmUrl, { headers });
+        if (resp.status === 304) {
+          // Server confirmed the content is unchanged — the cached hash is valid.
+          const cosBlob = await tryReadFromCOS(entry.hash);
+          if (cosBlob) {
+            const blob =
+              cosBlob.type === 'application/wasm'
+                ? cosBlob
+                : new Blob([cosBlob], { type: 'application/wasm' });
+            return URL.createObjectURL(blob);
+          }
+          // COS miss after a valid 304: fall through to re-fetch and re-populate.
+        } else if (resp.ok) {
+          // Content changed — compute new hash and update the cache entry.
+          const buf = await resp.arrayBuffer();
+          const hash = await computeSha256(buf);
+          const newEntry = { hash } as { hash: string; etag?: string; lastModified?: string };
+          const respEtag = resp.headers.get('etag');
+          const respLastMod = resp.headers.get('last-modified');
+          if (respEtag) newEntry.etag = respEtag;
+          if (respLastMod) newEntry.lastModified = respLastMod;
+          await setWasmCacheEntry(wasmUrl, newEntry);
+          const blob = new Blob([buf], { type: 'application/wasm' });
+          void writeToCosByHash(blob, hash);
           return URL.createObjectURL(blob);
         }
+        // Any other status falls through to the unconditional fetch below.
       }
     } catch {
-      hash = null;
+      // Non-fatal — fall through to unconditional fetch.
     }
 
-    // COS miss — fetch from the network.
-    // This is intentionally outside the try/catch: a 404 or network error
-    // here means the WASM is genuinely unavailable.  Returning wasmUrl as a
-    // fallback would only cause the Worker to make the same failing request
-    // and crash with a cryptic "expected magic word" error.
+    // First visit or no usable validation headers: fetch unconditionally.
+    // A 404 or network error here means the WASM is genuinely unavailable;
+    // returning wasmUrl as a fallback would only cause the Worker to crash
+    // with a cryptic "expected magic word" error.
     const response = await fetch(wasmUrl);
     if (!response.ok) {
       throw new Error(
@@ -403,18 +426,13 @@ export class CacheManager {
       );
     }
     const buf = await response.arrayBuffer();
-
-    if (!hash) {
-      // Compute and persist the hash so future loads can skip this fetch.
-      const hashBuf = await crypto.subtle.digest('SHA-256', buf);
-      hash = Array.from(new Uint8Array(hashBuf))
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join('');
-      await setUrlHash(wasmUrl, hash);
-    }
-
-    // Write to COS in the background; return a blob: URL from the
-    // already-fetched buffer so the Worker doesn't fetch it again.
+    const hash = await computeSha256(buf);
+    const entry = { hash } as { hash: string; etag?: string; lastModified?: string };
+    const etag = response.headers.get('etag');
+    const lastMod = response.headers.get('last-modified');
+    if (etag) entry.etag = etag;
+    if (lastMod) entry.lastModified = lastMod;
+    await setWasmCacheEntry(wasmUrl, entry);
     const blob = new Blob([buf], { type: 'application/wasm' });
     void writeToCosByHash(blob, hash);
     return URL.createObjectURL(blob);
@@ -553,6 +571,13 @@ export class CacheManager {
 }
 
 export default CacheManager;
+
+async function computeSha256(buf: ArrayBuffer): Promise<string> {
+  const hashBuf = await crypto.subtle.digest('SHA-256', buf);
+  return Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
 
 /**
  * Write to OPFS file from ReadableStream

--- a/src/cross-origin-storage-types.d.ts
+++ b/src/cross-origin-storage-types.d.ts
@@ -1,0 +1,29 @@
+/**
+ * TypeScript ambient declarations for the Cross-Origin Storage API.
+ * Source: https://github.com/WICG/cross-origin-storage/blob/main/cross-origin-storage.d.ts
+ */
+
+interface CrossOriginStorageRequestFileHandleHash {
+  value: string;
+  algorithm: string;
+}
+
+interface CrossOriginStorageRequestFileHandleOptions {
+  create?: boolean;
+  origins?: string[] | string;
+}
+
+interface CrossOriginStorageManager {
+  requestFileHandles(
+    hashes: CrossOriginStorageRequestFileHandleHash[],
+    options?: CrossOriginStorageRequestFileHandleOptions
+  ): Promise<FileSystemFileHandle[]>;
+}
+
+interface Navigator {
+  readonly crossOriginStorage: CrossOriginStorageManager;
+}
+
+interface WorkerNavigator {
+  readonly crossOriginStorage: CrossOriginStorageManager;
+}

--- a/src/cross-origin-storage.ts
+++ b/src/cross-origin-storage.ts
@@ -1,0 +1,154 @@
+/// <reference path="./cross-origin-storage-types.d.ts" />
+
+/**
+ * Cross-Origin Storage (COS) progressive enhancement.
+ *
+ * COS allows files identified by SHA-256 hash to be shared across origins, so a model
+ * downloaded by one site is instantly available to any other site that opts in.
+ *
+ * Spec: https://github.com/WICG/cross-origin-storage
+ * Extension: https://chromewebstore.google.com/detail/cross-origin-storage/denpnpcgjgikjpoglpjefakmdcbmlgih
+ */
+
+const COS_HASH_CACHE_NAME = 'wllama-cos-hash-cache';
+const HASH_ALGORITHM = 'SHA-256';
+
+function makeHashDescriptor(
+  value: string
+): CrossOriginStorageRequestFileHandleHash {
+  return { algorithm: HASH_ALGORITHM, value };
+}
+
+/**
+ * Returns true when the experimental Cross-Origin Storage API is available in
+ * the current browser context (requires the COS extension or native support).
+ */
+export function isCrossOriginStorageAvailable(): boolean {
+  return (
+    typeof navigator !== 'undefined' && 'crossOriginStorage' in navigator
+  );
+}
+
+/**
+ * Resolve the SHA-256 hash for a URL.
+ *
+ * Strategy (cheapest first):
+ * 1. Return the previously-cached hash from the wllama-cos-hash-cache Cache API bucket.
+ * 2. Fetch the Hugging Face Git LFS pointer file (only for /resolve/ URLs) and extract
+ *    the `oid sha256:` field.  This avoids reading the model file itself.
+ * 3. Return null – no hash available without full-file download.
+ */
+export async function resolveUrlHash(url: string): Promise<string | null> {
+  const cached = await getHashFromCache(url);
+  if (cached) return cached;
+
+  const lfsHash = await getLfsHash(url);
+  if (lfsHash) {
+    await setHashInCache(url, lfsHash);
+    return lfsHash;
+  }
+
+  return null;
+}
+
+/**
+ * Persist a URL → SHA-256 hash mapping so that future calls to `resolveUrlHash`
+ * return immediately without a network round-trip.
+ */
+export async function setUrlHash(url: string, hash: string): Promise<void> {
+  await setHashInCache(url, hash);
+}
+
+/**
+ * Attempt to retrieve a file from Cross-Origin Storage by its SHA-256 hash.
+ *
+ * Returns `null` when:
+ * - the COS API is unavailable
+ * - the file is not present (or is privacy-gated by the browser)
+ * - any unexpected error occurs
+ */
+export async function tryReadFromCOS(hash: string): Promise<Blob | null> {
+  if (!isCrossOriginStorageAvailable()) return null;
+  try {
+    const [handle] = await navigator.crossOriginStorage.requestFileHandles([
+      makeHashDescriptor(hash),
+    ]);
+    return handle.getFile();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a `Blob` to Cross-Origin Storage under the given SHA-256 hash.
+ *
+ * The browser verifies that the hash of the written data matches `hash`.
+ * Errors are swallowed – a COS write failure must never surface to the caller
+ * because the file is already safely stored in OPFS.
+ */
+export async function writeToCosByHash(
+  blob: Blob,
+  hash: string
+): Promise<void> {
+  if (!isCrossOriginStorageAvailable()) return;
+  try {
+    const nav = navigator as any;
+    const [handle]: FileSystemFileHandle[] =
+      await nav.crossOriginStorage.requestFileHandles(
+        [makeHashDescriptor(hash)],
+        { create: true }
+      );
+    const writable = await (handle as any).createWritable();
+    await writable.write(blob);
+    await writable.close();
+  } catch {
+    // Non-fatal: COS write failure must not affect the calling code.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function getHashFromCache(url: string): Promise<string | null> {
+  try {
+    const cache = await caches.open(COS_HASH_CACHE_NAME);
+    const resp = await cache.match(url);
+    return resp ? resp.text() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function setHashInCache(url: string, hash: string): Promise<void> {
+  try {
+    const cache = await caches.open(COS_HASH_CACHE_NAME);
+    await cache.put(url, new Response(hash));
+  } catch {
+    // Cache API may be unavailable in some contexts (e.g. non-secure origins).
+  }
+}
+
+/**
+ * Fetch the SHA-256 hash from a Hugging Face Git LFS pointer file.
+ *
+ * HF stores large files in Git LFS. The `/raw/` endpoint returns the raw LFS
+ * pointer (a small text file) instead of the actual blob, so we can learn the
+ * content hash without downloading the multi-gigabyte model.
+ *
+ * Only works for URLs that contain `/resolve/` (the standard HF download path).
+ * Returns null for non-HF or non-LFS URLs.
+ */
+async function getLfsHash(url: string): Promise<string | null> {
+  if (!url.includes('/resolve/')) return null;
+  // Swap /resolve/ for /raw/ to reach the LFS pointer; keep auth query params.
+  const rawUrl = url.replace('/resolve/', '/raw/');
+  try {
+    const text = await fetch(rawUrl).then((r) => r.text());
+    // LFS pointer format: "oid sha256:<hex>\n"
+    const match = text.match(/^oid sha256:([0-9a-f]+)$/m);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/cross-origin-storage.ts
+++ b/src/cross-origin-storage.ts
@@ -13,6 +13,18 @@
 const COS_HASH_CACHE_NAME = 'wllama-cos-hash-cache';
 const HASH_ALGORITHM = 'SHA-256';
 
+/**
+ * Cached metadata for a locally-computed WASM hash entry.
+ * Storing HTTP validation headers alongside the hash allows a future load to
+ * issue a cheap conditional GET (If-None-Match / If-Modified-Since) and get
+ * a 304 instead of re-downloading the whole file.
+ */
+export interface WasmCacheEntry {
+  hash: string;
+  etag?: string;
+  lastModified?: string;
+}
+
 function makeHashDescriptor(
   value: string
 ): CrossOriginStorageRequestFileHandleHash {
@@ -114,7 +126,15 @@ async function getHashFromCache(url: string): Promise<string | null> {
   try {
     const cache = await caches.open(COS_HASH_CACHE_NAME);
     const resp = await cache.match(url);
-    return resp ? resp.text() : null;
+    if (!resp) return null;
+    const text = await resp.text();
+    // Handle both legacy plain-string entries and newer JSON entries.
+    try {
+      const parsed = JSON.parse(text);
+      return typeof parsed.hash === 'string' ? parsed.hash : null;
+    } catch {
+      return text || null;
+    }
   } catch {
     return null;
   }
@@ -124,6 +144,39 @@ async function setHashInCache(url: string, hash: string): Promise<void> {
   try {
     const cache = await caches.open(COS_HASH_CACHE_NAME);
     await cache.put(url, new Response(hash));
+  } catch {
+    // Cache API may be unavailable in some contexts (e.g. non-secure origins).
+  }
+}
+
+export async function getWasmCacheEntry(
+  url: string
+): Promise<WasmCacheEntry | null> {
+  try {
+    const cache = await caches.open(COS_HASH_CACHE_NAME);
+    const resp = await cache.match(url);
+    if (!resp) return null;
+    const text = await resp.text();
+    try {
+      const parsed = JSON.parse(text);
+      if (typeof parsed.hash === 'string') return parsed as WasmCacheEntry;
+    } catch {
+      // Legacy plain-string entry — no validation headers available.
+      if (text) return { hash: text };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setWasmCacheEntry(
+  url: string,
+  entry: WasmCacheEntry
+): Promise<void> {
+  try {
+    const cache = await caches.open(COS_HASH_CACHE_NAME);
+    await cache.put(url, new Response(JSON.stringify(entry)));
   } catch {
     // Cache API may be unavailable in some contexts (e.g. non-secure origins).
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export * from './model-manager';
 export * from './huggingface';
 export * from './types/types';
 export * from './types/oai-compat';
+export * from './cross-origin-storage';
 export { CacheManager } from './cache-manager';
 export { isValidGgufFile } from './utils';

--- a/src/model-manager.ts
+++ b/src/model-manager.ts
@@ -115,17 +115,30 @@ export class Model {
         'load_error'
       );
     }
-    const blobs: Blob[] = [];
-    for (const file of this.files) {
-      const blob = await this.modelManager.cacheManager.open(file.name);
-      if (!blob) {
-        throw new Error(
-          `Failed to open file ${file.name}; Hint: the model may be invalid, please refresh it`
-        );
+    // Helper: attempt to open all shards; returns null on the first miss.
+    const tryOpen = async (): Promise<Blob[] | null> => {
+      const out: Blob[] = [];
+      for (const file of this.files) {
+        const blob = await this.modelManager.cacheManager.open(file.name);
+        if (!blob) return null;
+        out.push(blob);
       }
-      blobs.push(blob);
-    }
-    return blobs;
+      return out;
+    };
+
+    const blobs = await tryOpen();
+    if (blobs !== null) return blobs;
+
+    // One or more files are unavailable (e.g. evicted from COS).
+    // Re-download all shards and retry once.
+    await this.refresh();
+    const retried = await tryOpen();
+    if (retried !== null) return retried;
+
+    throw new WllamaError(
+      'Model files are unavailable even after re-download',
+      'load_error'
+    );
   }
   /**
    * Validate the model files.
@@ -169,7 +182,19 @@ export class Model {
     this.modelManager.logger.debug('Downloading model files:', urls);
     const nParallel =
       this.modelManager.params.parallelDownloads ?? DEFAULT_PARALLEL_DOWNLOADS;
-    const totalSize = await this.getTotalDownloadSize(urls);
+
+    // Pre-check Cross-Origin Storage for all shards in parallel.
+    // If every shard is already in COS we know the sizes immediately and can
+    // skip the HEAD request(s) to the origin server entirely.
+    // download() will re-check COS internally using the hash already cached in
+    // the wllama-cos-hash-cache Cache API bucket, so the second lookup is fast.
+    const cosBlobs = await Promise.all(
+      urls.map((url) => this.modelManager.cacheManager.checkCOS(url))
+    );
+    const allInCOS = cosBlobs.every((b) => b !== null);
+    const totalSize = allInCOS
+      ? cosBlobs.reduce((sum, b) => sum + b!.size, 0)
+      : await this.getTotalDownloadSize(urls);
     const loadedSize: number[] = [];
     const worker = async () => {
       while (works.length > 0) {

--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -487,6 +487,7 @@ export class Wllama {
 
     // initialize the worker
     const workerResources = this.getWorkerResources();
+    workerResources.wasmPath = await this.cacheManager.resolveWasmUrl(workerResources.wasmPath);
     this.proxy = new ProxyToWorker(
       workerResources,
       this.useMultiThread ? nbThreads : 0, // 0 means disable pthread

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -23,7 +23,7 @@
     "verbatimModuleSyntax": true,
 
     "noEmit": false,
-    "module": "es2015",
+    "module": "es2020",
     "outDir": "esm",
     "rootDir": "./src",
     "baseUrl": ".",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,7 +15,7 @@ const baseConfig: Options = {
 const browserConfig: Options = {
   ...baseConfig,
   platform: 'browser',
-  target: 'es2015',
+  target: 'es2020',
   splitting: false,
   outDir: 'esm',
 };


### PR DESCRIPTION
Similar to https://github.com/huggingface/transformers.js/pull/1549 for **Transformers.js** and https://github.com/mlc-ai/web-llm/pull/748, https://github.com/apache/tvm/pull/18893 for **WebLLM**, I'd like to add support for [Cross-Origin Storage](https://github.com/WICG/cross-origin-storage?tab=readme-ov-file) (COS) support as a progressive enhancement to **wllama** as well.

With COS supported in the browser (for now through an [extension](https://chromewebstore.google.com/detail/cross-origin-storage/denpnpcgjgikjpoglpjefakmdcbmlgih) until native support lands), large resources like the model files and the Wasm file don't have to be downloaded and cached for each origin but just once, and can the be shared across origins:
 
<img width="1772" height="1372" alt="Screenshot 2026-06-01 at 16 53 19" src="https://github.com/user-attachments/assets/6c072d68-1b30-434c-80fb-14d9f270eb8e" />

(Full disclosure: I'm one of the co-authors of the Cross-Origin Storage proposal. The objective is to add this API to the Web platform, see its [ChromeStatus entry](https://chromestatus.com/feature/5163371507875840).)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Cross-Origin Storage support for enhanced caching and improved offline resilience.
  * Added automatic retry mechanism when cached model files are unavailable or evicted.

* **Chores**
  * Updated build configuration to ES2020 module target for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->