### PR TITLE
add cross origin storage support

### DIFF
--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -2,7 +2,6 @@ import { getHFFileSHA256 } from './huggingface';
 import type { DownloadProgressCallback } from './model-manager';
 import { COSBackend } from './storage/cos';
 import type { StorageBackend, StorageFileHint } from './storage/index';
-import { OPFSBackend } from './storage/opfs';
 
 const PREFIX_METADATA = '__metadata__';
 
@@ -87,7 +86,7 @@ export class CacheManager {
    * @param backends Array of storage backends to use, in order of preference ; if first is available, use it, otherwise try the next one.
    */
   constructor(
-    backends: StorageBackend[] = [new COSBackend(), new OPFSBackend()]
+    backends: StorageBackend[] = [new COSBackend()]
   ) {
     for (const backend of backends) {
       if (backend.isSupported()) {
@@ -127,6 +126,16 @@ export class CacheManager {
   async download(url: string, options: DownloadOptions = {}): Promise<void> {
     const fileKey = await urlToFileName(url, '');
 
+    // Fetch sha256 before the GET so we can skip the download entirely if the
+    // file is already in COS (avoids opening a connection just to cancel it).
+    const sha256 = await getHFFileSHA256(url, options.headers ?? {});
+    const hint = sha256 ? { sha256 } : undefined;
+
+    if (hint && (await this.sb.getSize(fileKey, hint)) !== -1) {
+      // File already in COS; metadata was written on the original download.
+      return;
+    }
+
     const response = await fetch(url, {
       ...(options.headers ? { headers: options.headers } : {}),
       ...(options.signal ? { signal: options.signal } : {}),
@@ -164,9 +173,6 @@ export class CacheManager {
       },
     });
 
-    // for COS backend, we also fetch the sha256 from git LFS pointer
-    const sha256 = await getHFFileSHA256(url, options.headers ?? {});
-
     const metadata: CacheEntryMetadata = {
       originalURL: url,
       originalSize: total,
@@ -175,13 +181,6 @@ export class CacheManager {
     };
     if (sha256) {
       metadata.sha256 = sha256;
-    }
-
-    const hint = hintFromMetadata(metadata);
-    if (hint && (await this.sb.getSize(fileKey, hint)) !== -1) {
-      response.body?.cancel();
-      await this.writeMetadata(fileKey, metadata);
-      return;
     }
 
     await this.sb.write(

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -312,7 +312,8 @@ export class CacheManager {
 export default CacheManager;
 
 function sha256FromEtag(etag: string): StorageFileHint | undefined {
-  if (/^[0-9a-f]{64}$/.test(etag)) return { sha256: etag };
+  const normalized = etag.toLowerCase();
+  if (/^[0-9a-f]{64}$/.test(normalized)) return { sha256: normalized };
   return undefined;
 }
 

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -130,7 +130,27 @@ export class CacheManager {
     const hint = sha256 ? { sha256 } : undefined;
 
     if (hint && (await this.sb.getSize(fileKey, hint)) !== -1) {
-      // File already in COS; metadata was written on the original download.
+      // File already in COS. Metadata is origin-local (OPFS), so it may be
+      // absent on a different origin or after a crash between write and
+      // writeMetadata. Ensure it exists before returning.
+      if (!(await this.getMetadata(fileKey))) {
+        const head = await fetch(url, {
+          method: 'HEAD',
+          ...(options.headers ? { headers: options.headers } : {}),
+        });
+        const contentLength = head.headers.get('content-length');
+        const etag = (head.headers.get('etag') || '').replace(
+          /[^A-Za-z0-9]/g,
+          ''
+        );
+        await this.writeMetadata(fileKey, {
+          originalURL: url,
+          originalSize: parseInt(contentLength ?? '0', 10),
+          etag,
+          sha256,
+          ...(options.metadataAdditional ?? {}),
+        });
+      }
       return;
     }
 

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -1,3 +1,4 @@
+import { getHFFileSHA256 } from './huggingface';
 import type { DownloadProgressCallback } from './model-manager';
 import { COSBackend } from './storage/cos';
 import type { StorageBackend, StorageFileHint } from './storage/index';
@@ -60,6 +61,18 @@ export interface CacheEntryMetadata {
    * URL to mmproj file, if exists
    */
   mmprojURL?: string | undefined;
+  /**
+   * Optional SHA256, mostly used by COS backend
+   */
+  sha256?: string | undefined;
+}
+
+function hintFromMetadata(
+  metadata: CacheEntryMetadata | null
+): StorageFileHint | undefined {
+  if (!metadata) return undefined;
+  if (metadata.sha256) return { sha256: metadata.sha256 };
+  return undefined;
 }
 
 /**
@@ -151,14 +164,20 @@ export class CacheManager {
       },
     });
 
+    // for COS backend, we also fetch the sha256 from git LFS pointer
+    const sha256 = await getHFFileSHA256(url, options.headers ?? {});
+
     const metadata: CacheEntryMetadata = {
       originalURL: url,
       originalSize: total,
       etag,
       ...(options.metadataAdditional ?? {}),
     };
-    const hint = sha256FromEtag(etag);
+    if (sha256) {
+      metadata.sha256 = sha256;
+    }
 
+    const hint = hintFromMetadata(metadata);
     if (hint && (await this.sb.getSize(fileKey, hint)) !== -1) {
       response.body?.cancel();
       await this.writeMetadata(fileKey, metadata);
@@ -180,14 +199,12 @@ export class CacheManager {
    * @returns Blob, or null if file does not exist
    */
   async open(nameOrURL: string): Promise<Blob | null> {
-    const hint1 = sha256FromEtag(
-      (await this.getMetadata(nameOrURL))?.etag ?? ''
-    );
+    const hint1 = hintFromMetadata(await this.getMetadata(nameOrURL));
     const direct = await this.sb.read(nameOrURL, hint1);
     if (direct) return direct;
     // also accept the original URL
     const key = await urlToFileName(nameOrURL, '');
-    const hint2 = sha256FromEtag((await this.getMetadata(key))?.etag ?? '');
+    const hint2 = hintFromMetadata(await this.getMetadata(key));
     return this.sb.read(key, hint2);
   }
 
@@ -200,7 +217,7 @@ export class CacheManager {
    * @returns number of bytes, or -1 if file does not exist
    */
   async getSize(name: string): Promise<number> {
-    const hint = sha256FromEtag((await this.getMetadata(name))?.etag ?? '');
+    const hint = hintFromMetadata(await this.getMetadata(name));
     return this.sb.getSize(name, hint);
   }
 
@@ -310,12 +327,6 @@ export class CacheManager {
 }
 
 export default CacheManager;
-
-function sha256FromEtag(etag: string): StorageFileHint | undefined {
-  const normalized = etag.toLowerCase();
-  if (/^[0-9a-f]{64}$/.test(normalized)) return { sha256: normalized };
-  return undefined;
-}
 
 async function urlToFileName(url: string, prefix: string): Promise<string> {
   const hashBuffer = await crypto.subtle.digest(

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -1,5 +1,6 @@
 import type { DownloadProgressCallback } from './model-manager';
-import type { StorageBackend } from './storage/index';
+import { COSBackend } from './storage/cos';
+import type { StorageBackend, StorageFileHint } from './storage/index';
 import { OPFSBackend } from './storage/opfs';
 
 const PREFIX_METADATA = '__metadata__';
@@ -69,8 +70,19 @@ export interface CacheEntryMetadata {
 export class CacheManager {
   private sb: StorageBackend;
 
-  constructor(backend: StorageBackend = new OPFSBackend()) {
-    this.sb = backend;
+  /**
+   * @param backends Array of storage backends to use, in order of preference ; if first is available, use it, otherwise try the next one.
+   */
+  constructor(
+    backends: StorageBackend[] = [new COSBackend(), new OPFSBackend()]
+  ) {
+    for (const backend of backends) {
+      if (backend.isSupported()) {
+        this.sb = backend;
+        return;
+      }
+    }
+    throw new Error('No supported storage backend found');
   }
 
   /**
@@ -139,14 +151,26 @@ export class CacheManager {
       },
     });
 
-    await this.sb.write(fileKey, response.body.pipeThrough(progressStream));
-
-    await this.writeMetadata(fileKey, {
+    const metadata: CacheEntryMetadata = {
       originalURL: url,
       originalSize: total,
       etag,
       ...(options.metadataAdditional ?? {}),
-    });
+    };
+    const hint = sha256FromEtag(etag);
+
+    if (hint && (await this.sb.getSize(fileKey, hint)) !== -1) {
+      response.body?.cancel();
+      await this.writeMetadata(fileKey, metadata);
+      return;
+    }
+
+    await this.sb.write(
+      fileKey,
+      response.body.pipeThrough(progressStream),
+      hint
+    );
+    await this.writeMetadata(fileKey, metadata);
   }
 
   /**
@@ -156,11 +180,15 @@ export class CacheManager {
    * @returns Blob, or null if file does not exist
    */
   async open(nameOrURL: string): Promise<Blob | null> {
-    const direct = await this.sb.read(nameOrURL);
+    const hint1 = sha256FromEtag(
+      (await this.getMetadata(nameOrURL))?.etag ?? ''
+    );
+    const direct = await this.sb.read(nameOrURL, hint1);
     if (direct) return direct;
     // also accept the original URL
     const key = await urlToFileName(nameOrURL, '');
-    return this.sb.read(key);
+    const hint2 = sha256FromEtag((await this.getMetadata(key))?.etag ?? '');
+    return this.sb.read(key, hint2);
   }
 
   /**
@@ -172,7 +200,8 @@ export class CacheManager {
    * @returns number of bytes, or -1 if file does not exist
    */
   async getSize(name: string): Promise<number> {
-    return this.sb.getSize(name);
+    const hint = sha256FromEtag((await this.getMetadata(name))?.etag ?? '');
+    return this.sb.getSize(name, hint);
   }
 
   /**
@@ -281,6 +310,11 @@ export class CacheManager {
 }
 
 export default CacheManager;
+
+function sha256FromEtag(etag: string): StorageFileHint | undefined {
+  if (/^[0-9a-f]{64}$/.test(etag)) return { sha256: etag };
+  return undefined;
+}
 
 async function urlToFileName(url: string, prefix: string): Promise<string> {
   const hashBuffer = await crypto.subtle.digest(

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -85,9 +85,7 @@ export class CacheManager {
   /**
    * @param backends Array of storage backends to use, in order of preference ; if first is available, use it, otherwise try the next one.
    */
-  constructor(
-    backends: StorageBackend[] = [new COSBackend()]
-  ) {
+  constructor(backends: StorageBackend[] = [new COSBackend()]) {
     for (const backend of backends) {
       if (backend.isSupported()) {
         this.sb = backend;

--- a/src/huggingface.ts
+++ b/src/huggingface.ts
@@ -134,3 +134,18 @@ export async function getHFModelSource(
 
   return source;
 }
+
+export async function getHFFileSHA256(
+  url: string,
+  headers: Record<string, string>
+): Promise<string | undefined> {
+  if (!url.includes('/resolve/')) return undefined;
+  const rawUrl = url.replace('/resolve/', '/raw/');
+  try {
+    const text = await fetch(rawUrl, { headers }).then((r) => r.text());
+    const match = text.match(/^oid sha256:([0-9a-f]+)$/m);
+    return match ? match[1] : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/huggingface.ts
+++ b/src/huggingface.ts
@@ -143,7 +143,7 @@ export async function getHFFileSHA256(
   const rawUrl = url.replace('/resolve/', '/raw/');
   try {
     const text = await fetch(rawUrl, { headers }).then((r) => r.text());
-    const match = text.match(/^oid sha256:([0-9a-f]+)$/m);
+    const match = text.match(/^oid sha256:([0-9a-f]{64})$/m);
     return match ? match[1] : undefined;
   } catch {
     return undefined;

--- a/src/storage/cos.test.ts
+++ b/src/storage/cos.test.ts
@@ -1,0 +1,84 @@
+import { test, expect, beforeEach } from 'vitest';
+import { COSBackend, mockCOS } from './cos';
+import CacheManager from '../cache-manager';
+
+async function randomBufAndHash(): Promise<{
+  buf: Uint8Array;
+  sha256: string;
+}> {
+  const buf = crypto.getRandomValues(new Uint8Array(256));
+  const hashBuf = await crypto.subtle.digest('SHA-256', buf);
+  const sha256 = Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return { buf, sha256 };
+}
+
+function bufStream(buf: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(buf.slice());
+      controller.close();
+    },
+  });
+}
+
+test.sequential('write then read without hint falls back to OPFS', async () => {
+  const backend = new COSBackend();
+  const { buf } = await randomBufAndHash();
+  const key = 'test-no-hint';
+
+  await backend.write(key, bufStream(buf));
+  const blob = await backend.read(key);
+  expect(blob).not.toBeNull();
+  expect(new Uint8Array(await blob!.arrayBuffer())).toEqual(buf);
+
+  await backend.delete(key);
+});
+
+beforeEach(() => {
+  mockCOS();
+});
+
+test.sequential('write with hint stores in COS only', async () => {
+  const backend = new COSBackend();
+  expect(backend.isSupported()).toBe(true);
+
+  const { buf, sha256 } = await randomBufAndHash();
+  const hint = { sha256 };
+  const key = 'test-with-hint';
+
+  await backend.write(key, bufStream(buf), hint);
+
+  // read back via hint → should hit COS
+  const blob = await backend.read(key, hint);
+  expect(blob).not.toBeNull();
+  expect(new Uint8Array(await blob!.arrayBuffer())).toEqual(buf);
+
+  // without hint → OPFS fallback → not found (was written to COS only)
+  const blobOpfs = await backend.read(key);
+  expect(blobOpfs).toBeNull();
+
+  await backend.delete(key);
+});
+
+test.sequential('getSize with hint reflects COS size', async () => {
+  const backend = new COSBackend();
+  const { buf, sha256 } = await randomBufAndHash();
+  const hint = { sha256 };
+  const key = 'test-size-hint';
+
+  await backend.write(key, bufStream(buf), hint);
+
+  const size = await backend.getSize(key, hint);
+  expect(size).toBe(buf.byteLength);
+
+  await backend.delete(key);
+});
+
+test.sequential('read missing key returns null', async () => {
+  const backend = new COSBackend();
+  const { sha256 } = await randomBufAndHash();
+  const blob = await backend.read('non-existent-key', { sha256 });
+  expect(blob).toBeNull();
+});

--- a/src/storage/cos.test.ts
+++ b/src/storage/cos.test.ts
@@ -1,6 +1,5 @@
 import { test, expect, beforeEach } from 'vitest';
 import { COSBackend, mockCOS } from './cos';
-import CacheManager from '../cache-manager';
 
 async function randomBufAndHash(): Promise<{
   buf: Uint8Array;

--- a/src/storage/cos.ts
+++ b/src/storage/cos.ts
@@ -15,7 +15,7 @@ interface CrossOriginStorageManager {
 
 declare global {
   interface Navigator {
-    readonly crossOriginStorage: CrossOriginStorageManager;
+    readonly crossOriginStorage?: CrossOriginStorageManager;
   }
 }
 
@@ -34,7 +34,7 @@ class COSInternalBackend implements StorageBackend {
   // IMPORTANT: key must be SHA-256 hash of the data
   async read(key: string): Promise<Blob | null> {
     try {
-      const [handle] = await navigator.crossOriginStorage.requestFileHandles([
+      const [handle] = await navigator.crossOriginStorage!.requestFileHandles([
         makeHash(key),
       ]);
       return handle.getFile();
@@ -45,7 +45,7 @@ class COSInternalBackend implements StorageBackend {
 
   // IMPORTANT: key must be SHA-256 hash of the data
   async write(key: string, stream: ReadableStream): Promise<void> {
-    const [handle] = await navigator.crossOriginStorage.requestFileHandles(
+    const [handle] = await navigator.crossOriginStorage!.requestFileHandles(
       [makeHash(key)],
       { create: true }
     );
@@ -65,7 +65,7 @@ class COSInternalBackend implements StorageBackend {
   // IMPORTANT: key must be SHA-256 hash of the data
   async getSize(key: string): Promise<number> {
     try {
-      const [handle] = await navigator.crossOriginStorage.requestFileHandles([
+      const [handle] = await navigator.crossOriginStorage!.requestFileHandles([
         makeHash(key),
       ]);
       const file = await handle.getFile();

--- a/src/storage/cos.ts
+++ b/src/storage/cos.ts
@@ -1,0 +1,139 @@
+import type { StorageBackend, StorageFileHint } from './index';
+import { OPFSBackend } from './opfs';
+
+interface CrossOriginStorageRequestFileHandleHash {
+  value: string;
+  algorithm: string;
+}
+
+interface CrossOriginStorageManager {
+  requestFileHandles(
+    hashes: CrossOriginStorageRequestFileHandleHash[],
+    options?: { create?: boolean; origins?: string[] | string }
+  ): Promise<FileSystemFileHandle[]>;
+}
+
+declare global {
+  interface Navigator {
+    readonly crossOriginStorage: CrossOriginStorageManager;
+  }
+}
+
+function makeHash(key: string): CrossOriginStorageRequestFileHandleHash {
+  return { algorithm: 'SHA-256', value: key };
+}
+
+// internal, non-standard implementation
+class COSInternalBackend implements StorageBackend {
+  isSupported(): boolean {
+    return (
+      typeof navigator !== 'undefined' && 'crossOriginStorage' in navigator
+    );
+  }
+
+  // IMPORTANT: key must be SHA-256 hash of the data
+  async read(key: string): Promise<Blob | null> {
+    try {
+      const [handle] = await navigator.crossOriginStorage.requestFileHandles([
+        makeHash(key),
+      ]);
+      return handle.getFile();
+    } catch {
+      return null;
+    }
+  }
+
+  // IMPORTANT: key must be SHA-256 hash of the data
+  async write(key: string, stream: ReadableStream): Promise<void> {
+    const [handle] = await navigator.crossOriginStorage.requestFileHandles(
+      [makeHash(key)],
+      { create: true }
+    );
+    const writable = await (handle as any).createWritable();
+    const reader = stream.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        await writable.write(value);
+      }
+    } finally {
+      await writable.close();
+    }
+  }
+
+  // IMPORTANT: key must be SHA-256 hash of the data
+  async getSize(key: string): Promise<number> {
+    try {
+      const [handle] = await navigator.crossOriginStorage.requestFileHandles([
+        makeHash(key),
+      ]);
+      const file = await handle.getFile();
+      return file.size;
+    } catch {
+      return -1;
+    }
+  }
+
+  async list(): Promise<Array<{ key: string; size: number }>> {
+    throw new Error('not implemented');
+  }
+
+  async delete(_key: string): Promise<void> {
+    throw new Error('not implemented');
+  }
+}
+
+/**
+ * Storage backend that uses the Cross-Origin Storage API
+ * Metadata is stored in OPFS, while the actual data is stored in COS
+ * If hint.sha256 is provided, it will be used as the key for COS, otherwise fallback to OPFS
+ */
+export class COSBackend implements StorageBackend {
+  private cos = new COSInternalBackend();
+  private priv = new OPFSBackend();
+
+  isSupported(): boolean {
+    return this.priv.isSupported();
+  }
+
+  async read(key: string, hint?: StorageFileHint): Promise<Blob | null> {
+    if (hint?.sha256 && this.cos.isSupported()) {
+      const blob = await this.cos.read(hint.sha256);
+      if (blob) return blob;
+    }
+    return this.priv.read(key);
+  }
+
+  async write(
+    key: string,
+    stream: ReadableStream,
+    hint?: StorageFileHint
+  ): Promise<void> {
+    if (hint?.sha256 && this.cos.isSupported()) {
+      const [s1, s2] = stream.tee();
+      await Promise.all([
+        this.cos.write(hint.sha256, s1),
+        this.priv.write(key, s2),
+      ]);
+    } else {
+      await this.priv.write(key, stream);
+    }
+  }
+
+  async getSize(key: string, hint?: StorageFileHint): Promise<number> {
+    if (hint?.sha256 && this.cos.isSupported()) {
+      const size = await this.cos.getSize(hint.sha256);
+      if (size !== -1) return size;
+    }
+    return this.priv.getSize(key);
+  }
+
+  async list(): Promise<Array<{ key: string; size: number }>> {
+    return this.priv.list();
+  }
+
+  async delete(key: string): Promise<void> {
+    return this.priv.delete(key);
+  }
+}

--- a/src/storage/cos.ts
+++ b/src/storage/cos.ts
@@ -111,11 +111,7 @@ export class COSBackend implements StorageBackend {
     hint?: StorageFileHint
   ): Promise<void> {
     if (hint?.sha256 && this.cos.isSupported()) {
-      const [s1, s2] = stream.tee();
-      await Promise.all([
-        this.cos.write(hint.sha256, s1),
-        this.priv.write(key, s2),
-      ]);
+      await this.cos.write(hint.sha256, stream);
     } else {
       await this.priv.write(key, stream);
     }
@@ -136,4 +132,43 @@ export class COSBackend implements StorageBackend {
   async delete(key: string): Promise<void> {
     return this.priv.delete(key);
   }
+}
+
+// used for testing only
+export function mockCOS(): void {
+  const store = new Map<string, Blob>();
+
+  (navigator as any).crossOriginStorage = {
+    async requestFileHandles(
+      hashes: CrossOriginStorageRequestFileHandleHash[],
+      options?: { create?: boolean }
+    ): Promise<FileSystemFileHandle[]> {
+      return hashes.map(({ value }) => {
+        if (!options?.create && !store.has(value)) {
+          throw new DOMException('File not found', 'NotFoundError');
+        }
+        return {
+          getFile() {
+            const blob = store.get(value);
+            if (!blob)
+              throw new DOMException('File not found', 'NotFoundError');
+            return Promise.resolve(new File([blob], value));
+          },
+          createWritable() {
+            const chunks: BlobPart[] = [];
+            return Promise.resolve({
+              write(chunk: BlobPart) {
+                chunks.push(chunk);
+                return Promise.resolve();
+              },
+              close() {
+                store.set(value, new Blob(chunks));
+                return Promise.resolve();
+              },
+            });
+          },
+        } as unknown as FileSystemFileHandle;
+      });
+    },
+  } satisfies CrossOriginStorageManager;
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,21 +1,31 @@
+export interface StorageFileHint {
+  sha256: string;
+}
+
 export interface StorageBackend {
+  isSupported(): boolean;
+
   /**
    * Read a file from storage by key.
    * @returns Blob, or null if the key does not exist
    */
-  read(key: string): Promise<Blob | null>;
+  read(key: string, hint?: StorageFileHint): Promise<Blob | null>;
 
   /**
    * Write a ReadableStream to storage under the given key.
    * Overwrites any existing content for that key.
    */
-  write(key: string, stream: ReadableStream): Promise<void>;
+  write(
+    key: string,
+    stream: ReadableStream,
+    hint?: StorageFileHint
+  ): Promise<void>;
 
   /**
    * Get the stored size of a file in bytes.
    * @returns number of bytes, or -1 if the key does not exist
    */
-  getSize(key: string): Promise<number>;
+  getSize(key: string, hint?: StorageFileHint): Promise<number>;
 
   /**
    * List all keys currently in storage.

--- a/src/storage/opfs.ts
+++ b/src/storage/opfs.ts
@@ -4,7 +4,11 @@ import type { StorageBackend } from './index';
 
 export class OPFSBackend implements StorageBackend {
   isSupported(): boolean {
-    return 'storage' in navigator && !!navigator.storage.getDirectory;
+    return (
+      typeof navigator !== 'undefined' &&
+      'storage' in navigator &&
+      !!navigator.storage?.getDirectory
+    );
   }
 
   async read(key: string): Promise<Blob | null> {

--- a/src/storage/opfs.ts
+++ b/src/storage/opfs.ts
@@ -3,6 +3,10 @@ import { OPFS_UTILS_WORKER_CODE } from '../workers-code/generated';
 import type { StorageBackend } from './index';
 
 export class OPFSBackend implements StorageBackend {
+  isSupported(): boolean {
+    return 'storage' in navigator && !!navigator.storage.getDirectory;
+  }
+
   async read(key: string): Promise<Blob | null> {
     try {
       const cacheDir = await getCacheDir();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       '**/examples/**',
       ...(!WEBGPU ? ['**/src/*.wgpu.test.*'] : []),
     ],
-    include: WEBGPU ? ['**/src/*.wgpu.test.*'] : ['**/src/*.test.*'],
+    include: WEBGPU ? ['**/src/*.wgpu.test.*'] : ['**/src/**/*.test.*'],
     browser: {
       enabled: true,
       name: process.env.BROWSER ?? 'chromium',


### PR DESCRIPTION
fix #246 , cc @tomayac

this is built on top of #247 , the implementation contains:
- `COSInternalBackend` that implements only the read and write ops (no list or delete)
- `COSBackend` maintains 2 sub-instances, `COSInternalBackend` and `OPFSBackend`
    - file's metadata is stored inside OPFS (that includes the etag)
    - actual file data is stored inside `COSInternalBackend`

when a file is requested:
- if it's a file to be downloaded from internet, get sha256 from git LFS pointer (if applicable) --> construct `hint` object --> query COS file using the sha256 hint
    - if file doesn't exist in COS, download it to COS, also write sha256 to file's metadata
    - if file exist, serve it
- if file metadata is found in OPFS --> get get the sha256 from metadata --> construct `hint` object --> query COS file using the sha256 hint

when the `CacheManager` is created, it picks COS if available, otherwise fallback to OPFS

## Class Diagram

```mermaid
classDiagram
    class StorageBackend {
        <<interface>>
        +isSupported() boolean
        +read(key, hint?) Promise~Blob|null~
        +write(key, stream, hint?) Promise~void~
        +getSize(key, hint?) Promise~number~
        +list() Promise~Array~
        +delete(key) Promise~void~
    }

    class StorageFileHint {
        <<interface>>
        +sha256: string
    }

    class OPFSBackend {
        +isSupported() boolean
        +read(key) Promise~Blob|null~
        +write(key, stream) Promise~void~
        +getSize(key) Promise~number~
        +list() Promise~Array~
        +delete(key) Promise~void~
    }

    class COSInternalBackend {
        <<internal>>
        +isSupported() boolean
        +read(key) Promise~Blob|null~
        +write(key, stream) Promise~void~
        +getSize(key) Promise~number~
        +list() throws Error
        +delete(key) throws Error
    }

    class COSBackend {
        -cos: COSInternalBackend
        -priv: OPFSBackend
        +isSupported() boolean
        +read(key, hint?) Promise~Blob|null~
        +write(key, stream, hint?) Promise~void~
        +getSize(key, hint?) Promise~number~
        +list() Promise~Array~
        +delete(key) Promise~void~
    }

    class CacheManager {
        -sb: StorageBackend
        +constructor(backends?)
        +getNameFromURL(url) Promise~string~
        +download(url, options?) Promise~void~
        +open(nameOrURL) Promise~Blob|null~
        +getSize(name) Promise~number~
        +getMetadata(name) Promise~CacheEntryMetadata|null~
        +list() Promise~CacheEntry[]~
        +clear() Promise~void~
        +delete(nameOrURL) Promise~void~
        +deleteMany(predicate) Promise~void~
        +writeMetadata(name, metadata) Promise~void~
    }

    class CacheEntry {
        <<interface>>
        +name: string
        +size: number
        +metadata: CacheEntryMetadata
    }

    class CacheEntryMetadata {
        <<interface>>
        +etag: string
        +originalSize: number
        +originalURL: string
        +mmprojURL?: string
    }

    class CrossOriginStorageManager {
        <<interface>>
        +requestFileHandles(hashes, options?) Promise~FileSystemFileHandle[]~
    }

    StorageBackend <|.. OPFSBackend : implements
    StorageBackend <|.. COSInternalBackend : implements
    StorageBackend <|.. COSBackend : implements
    COSBackend *-- COSInternalBackend : composes
    COSBackend *-- OPFSBackend : composes
    CacheManager o-- StorageBackend : uses
    CacheManager ..> CacheEntry : returns
    CacheEntry *-- CacheEntryMetadata : contains
    StorageBackend ..> StorageFileHint : uses hint
    COSInternalBackend ..> CrossOriginStorageManager : navigator.crossOriginStorage
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Cache now accepts multiple storage backends and automatically selects the first supported one.
  * Added SHA-256–based hints to improve caching accuracy and enable COS-backed storage for hinted content.
  * Cache can derive content hashes from Hugging Face resolved URLs to skip redundant downloads.
* **Bug Fixes**
  * Hint-aware cache reads and size checks now correctly reuse cached entries and avoid unnecessary transfers.
* **Tests**
  * Added COS backend sequential tests and expanded Vitest discovery for nested test folders.
* **Utilities**
  * Added a helper to extract SHA-256 from Hugging Face resolved URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->