### PR TITLE
refactor(cos): use singular requestFileHandle() instead of requestFileHandles()

### DIFF
--- a/src/storage/cos.ts
+++ b/src/storage/cos.ts
@@ -34,8 +34,9 @@ class COSInternalBackend implements StorageBackend {
   // IMPORTANT: key must be SHA-256 hash of the data
   async read(key: string): Promise<Blob | null> {
     try {
-      const handle =
-        await navigator.crossOriginStorage!.requestFileHandle(makeHash(key));
+      const handle = await navigator.crossOriginStorage!.requestFileHandle(
+        makeHash(key)
+      );
       return handle.getFile();
     } catch {
       return null;
@@ -64,8 +65,9 @@ class COSInternalBackend implements StorageBackend {
   // IMPORTANT: key must be SHA-256 hash of the data
   async getSize(key: string): Promise<number> {
     try {
-      const handle =
-        await navigator.crossOriginStorage!.requestFileHandle(makeHash(key));
+      const handle = await navigator.crossOriginStorage!.requestFileHandle(
+        makeHash(key)
+      );
       const file = await handle.getFile();
       return file.size;
     } catch {
@@ -147,8 +149,7 @@ export function mockCOS(): void {
       return {
         getFile() {
           const blob = store.get(value);
-          if (!blob)
-            throw new DOMException('File not found', 'NotFoundError');
+          if (!blob) throw new DOMException('File not found', 'NotFoundError');
           return Promise.resolve(new File([blob], value));
         },
         createWritable() {

--- a/src/storage/cos.ts
+++ b/src/storage/cos.ts
@@ -34,9 +34,8 @@ class COSInternalBackend implements StorageBackend {
   // IMPORTANT: key must be SHA-256 hash of the data
   async read(key: string): Promise<Blob | null> {
     try {
-      const handle = await navigator.crossOriginStorage!.requestFileHandle(
-        makeHash(key)
-      );
+      const handle =
+        await navigator.crossOriginStorage!.requestFileHandle(makeHash(key));
       return handle.getFile();
     } catch {
       return null;
@@ -65,9 +64,8 @@ class COSInternalBackend implements StorageBackend {
   // IMPORTANT: key must be SHA-256 hash of the data
   async getSize(key: string): Promise<number> {
     try {
-      const handle = await navigator.crossOriginStorage!.requestFileHandle(
-        makeHash(key)
-      );
+      const handle =
+        await navigator.crossOriginStorage!.requestFileHandle(makeHash(key));
       const file = await handle.getFile();
       return file.size;
     } catch {

--- a/src/storage/cos.ts
+++ b/src/storage/cos.ts
@@ -7,10 +7,10 @@ interface CrossOriginStorageRequestFileHandleHash {
 }
 
 interface CrossOriginStorageManager {
-  requestFileHandles(
-    hashes: CrossOriginStorageRequestFileHandleHash[],
+  requestFileHandle(
+    hash: CrossOriginStorageRequestFileHandleHash,
     options?: { create?: boolean; origins?: string[] | string }
-  ): Promise<FileSystemFileHandle[]>;
+  ): Promise<FileSystemFileHandle>;
 }
 
 declare global {
@@ -34,9 +34,9 @@ class COSInternalBackend implements StorageBackend {
   // IMPORTANT: key must be SHA-256 hash of the data
   async read(key: string): Promise<Blob | null> {
     try {
-      const [handle] = await navigator.crossOriginStorage!.requestFileHandles([
-        makeHash(key),
-      ]);
+      const handle = await navigator.crossOriginStorage!.requestFileHandle(
+        makeHash(key)
+      );
       return handle.getFile();
     } catch {
       return null;
@@ -45,8 +45,8 @@ class COSInternalBackend implements StorageBackend {
 
   // IMPORTANT: key must be SHA-256 hash of the data
   async write(key: string, stream: ReadableStream): Promise<void> {
-    const [handle] = await navigator.crossOriginStorage!.requestFileHandles(
-      [makeHash(key)],
+    const handle = await navigator.crossOriginStorage!.requestFileHandle(
+      makeHash(key),
       { create: true }
     );
     const writable = await (handle as any).createWritable();
@@ -65,9 +65,9 @@ class COSInternalBackend implements StorageBackend {
   // IMPORTANT: key must be SHA-256 hash of the data
   async getSize(key: string): Promise<number> {
     try {
-      const [handle] = await navigator.crossOriginStorage!.requestFileHandles([
-        makeHash(key),
-      ]);
+      const handle = await navigator.crossOriginStorage!.requestFileHandle(
+        makeHash(key)
+      );
       const file = await handle.getFile();
       return file.size;
     } catch {
@@ -139,36 +139,34 @@ export function mockCOS(): void {
   const store = new Map<string, Blob>();
 
   (navigator as any).crossOriginStorage = {
-    async requestFileHandles(
-      hashes: CrossOriginStorageRequestFileHandleHash[],
+    async requestFileHandle(
+      { value }: CrossOriginStorageRequestFileHandleHash,
       options?: { create?: boolean }
-    ): Promise<FileSystemFileHandle[]> {
-      return hashes.map(({ value }) => {
-        if (!options?.create && !store.has(value)) {
-          throw new DOMException('File not found', 'NotFoundError');
-        }
-        return {
-          getFile() {
-            const blob = store.get(value);
-            if (!blob)
-              throw new DOMException('File not found', 'NotFoundError');
-            return Promise.resolve(new File([blob], value));
-          },
-          createWritable() {
-            const chunks: BlobPart[] = [];
-            return Promise.resolve({
-              write(chunk: BlobPart) {
-                chunks.push(chunk);
-                return Promise.resolve();
-              },
-              close() {
-                store.set(value, new Blob(chunks));
-                return Promise.resolve();
-              },
-            });
-          },
-        } as unknown as FileSystemFileHandle;
-      });
+    ): Promise<FileSystemFileHandle> {
+      if (!options?.create && !store.has(value)) {
+        throw new DOMException('File not found', 'NotFoundError');
+      }
+      return {
+        getFile() {
+          const blob = store.get(value);
+          if (!blob)
+            throw new DOMException('File not found', 'NotFoundError');
+          return Promise.resolve(new File([blob], value));
+        },
+        createWritable() {
+          const chunks: BlobPart[] = [];
+          return Promise.resolve({
+            write(chunk: BlobPart) {
+              chunks.push(chunk);
+              return Promise.resolve();
+            },
+            close() {
+              store.set(value, new Blob(chunks));
+              return Promise.resolve();
+            },
+          });
+        },
+      } as unknown as FileSystemFileHandle;
     },
   } satisfies CrossOriginStorageManager;
 }


### PR DESCRIPTION
Sorry @ngxson, this comes hot on the heels of your just-merged PR #248! The `requestFileHandles()` (plural) method is being renamed to `requestFileHandle()` (singular) in the COS spec. The change was driven by implementer feedback at **Web Engines Hackfest** this week: a survey of every known real-world implementation found that every single call site passed a single-element array and immediately destructured the result to one handle, so no one ever used the batching. The spec has been updated accordingly: WICG/cross-origin-storage#61.

**Changes:**
- Interface updated: `requestFileHandle(hash, options?)` returning `Promise<FileSystemFileHandle>` directly (no array wrapping)
- All three call sites in `COSInternalBackend` (`read`, `write`, `getSize`) updated
- `mockCOS()` updated to match the new singular signature

No test changes needed, as the tests go through `COSBackend`/`mockCOS()` and continue to pass as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated Cross-Origin Storage handling to use a simplified single-handle request flow, improving efficiency for reading and writing stored data.

* **Tests**
  * Updated the Cross-Origin Storage test helper to match the new single-handle behavior, including in-memory file reads and buffered writable writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->