### PR TITLE
Add `origins` option to `crossOriginStorage` request

### DIFF
--- a/src/storage/cos.ts
+++ b/src/storage/cos.ts
@@ -47,7 +47,7 @@ class COSInternalBackend implements StorageBackend {
   async write(key: string, stream: ReadableStream): Promise<void> {
     const handle = await navigator.crossOriginStorage!.requestFileHandle(
       makeHash(key),
-      { create: true }
+      { create: true, origins: '*' }
     );
     const writable = await (handle as any).createWritable();
     const reader = stream.getReader();


### PR DESCRIPTION
This makes the resources available globally. Initially this wasn't implemented in the extension, but the origins check is implemented now, so we need to update the code to make use of it. (Internally, the extension as a one-off upgrades all resources that were stored already as origins: '*'.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file access behavior for browser-based storage, which may help prevent issues when saving or opening files in cross-origin contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->