### PR TITLE
fix: don't stop polling get_result while results may still be queued

### DIFF
--- a/src/wllama.ts
+++ b/src/wllama.ts
@@ -1081,9 +1081,11 @@ export class Wllama {
         }
       }
 
-      if (!result_chunk.has_more) {
-        break;
-      }
+      // Do NOT break on has_more here: get_result pops one queued result per
+      // call while has_more reflects the task queue, so more results may still
+      // be queued even when has_more is false. Breaking early strands them,
+      // truncating this completion's tail and leaking it into the next one.
+      // Only an empty poll (handled above) confirms the queue is drained.
     }
 
     return finalResult;


### PR DESCRIPTION
Fixes #263

`getResponse()` broke out of its polling loop as soon as a `get_result` response carried `has_more: false`, even when that same response still contained data. On the wasm side, `action_get_result` pops only **one** queued result per call while `has_more` reflects *task*-queue emptiness, so results still queued when generation finishes were stranded — the completion lost its final tokens, and the stranded chunks were then drained by the **next** completion's first polls, prepending the previous answer's tail to the new answer's stream (details and reproduction in #263).

This change removes the early `break` after the data-processing branch so the loop keeps polling until an empty `get_result` response confirms the queue is drained — the empty-data branch already handles that termination correctly. Cost is one extra round-trip per completion.

**Verification:** the race is timing-dependent (it needs the worker to finish generating while results are still queued), so I couldn't find a reliable way to unit-test it; verified manually instead by running consecutive streamed completions on one instance (Qwen3 0.6B–8B, CPU and WebGPU) — before the change the previous answer's tail reliably appeared at the start of the next answer within a few completions; with the change applied (as a `getResponse` override in [HermitUI](https://github.com/moooff/HermitUI), which embeds wllama 3.5.1) all answers end complete and start clean across full 10-question runs.

`npm run build:tsup`, `npm run build:typedef` and prettier are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed response handling to ensure queued results are fully retrieved.
  * Prevented responses from being truncated when additional results become available after an intermediate empty queue indication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->