### PR TITLE
fix partially downloaded file

### DIFF
--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -129,29 +129,41 @@ export class CacheManager {
     const sha256 = await getHFFileSHA256(url, options.headers ?? {});
     const hint = sha256 ? { sha256 } : undefined;
 
-    if (hint && (await this.sb.getSize(fileKey, hint)) !== -1) {
-      // File already in COS. Metadata is origin-local (OPFS), so it may be
-      // absent on a different origin or after a crash between write and
-      // writeMetadata. Ensure it exists before returning.
-      if (!(await this.getMetadata(fileKey))) {
-        const head = await fetch(url, {
-          method: 'HEAD',
-          ...(options.headers ? { headers: options.headers } : {}),
-        });
-        const contentLength = head.headers.get('content-length');
-        const etag = (head.headers.get('etag') || '').replace(
-          /[^A-Za-z0-9]/g,
-          ''
-        );
+    const cachedSize = await this.sb.getSize(fileKey, hint);
+    if (cachedSize !== -1) {
+      const metadata = await this.readMetadata(fileKey);
+      if (
+        metadata?.originalURL === url &&
+        metadata.originalSize === cachedSize
+      ) {
+        return;
+      }
+      // no metadata, file maybe partial; ask server for the real size
+      const head = await fetch(url, {
+        method: 'HEAD',
+        ...(options.headers ? { headers: options.headers } : {}),
+      });
+      const originalSize = parseInt(
+        head.headers.get('content-length') ?? '0',
+        10
+      );
+      const etag = (head.headers.get('etag') || '').replace(
+        /[^A-Za-z0-9]/g,
+        ''
+      );
+      if (originalSize > 0 && originalSize === cachedSize) {
         await this.writeMetadata(fileKey, {
           originalURL: url,
-          originalSize: parseInt(contentLength ?? '0', 10),
+          originalSize,
           etag,
           sha256,
           ...(options.metadataAdditional ?? {}),
         });
+        return;
       }
-      return;
+      // size mismatch, drop the file and download it again
+      await this.sb.delete(fileKey);
+      await this.sb.delete(`${PREFIX_METADATA}${fileKey}`);
     }
 
     const response = await fetch(url, {
@@ -242,19 +254,26 @@ export class CacheManager {
    * Get metadata of a cached file
    */
   async getMetadata(name: string): Promise<CacheEntryMetadata | null> {
-    const blob = await this.sb.read(`${PREFIX_METADATA}${name}`);
+    const metadata = await this.readMetadata(name);
+    if (metadata) return metadata;
     const cachedSize = await this.sb.getSize(name);
-    if (!blob) {
-      return cachedSize > 0
-        ? // files created by older version of wllama don't have metadata; polyfill it
-          {
-            etag: POLYFILL_ETAG,
-            originalSize: cachedSize,
-            originalURL: '',
-          }
-        : // cached file not found
-          null;
-    }
+    return cachedSize > 0
+      ? // files created by older version of wllama don't have metadata; polyfill it
+        {
+          etag: POLYFILL_ETAG,
+          originalSize: cachedSize,
+          originalURL: '',
+        }
+      : // cached file not found
+        null;
+  }
+
+  /**
+   * Same as `getMetadata()`, but without polyfill. Returns null if the file has no metadata.
+   */
+  private async readMetadata(name: string): Promise<CacheEntryMetadata | null> {
+    const blob = await this.sb.read(`${PREFIX_METADATA}${name}`);
+    if (!blob) return null;
     try {
       return await new Response(blob).json();
     } catch (e) {

--- a/src/model-manager.test.ts
+++ b/src/model-manager.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from 'vitest';
 import { ModelManager, Model, ModelValidationStatus } from './model-manager';
+import { OPFSBackend } from './storage/opfs';
 
 const TINY_MODEL =
   'https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf';
@@ -104,6 +105,41 @@ test.skip('interrupt download split model (partial files downloaded)', async () 
   await expect(downloadPromise).rejects.toThrow('aborted');
   expect((await manager.getModels()).length).toBe(0);
   expect((await manager.getModels({ includeInvalid: true })).length).toBe(1);
+});
+
+test.sequential('recover from missing metadata', async () => {
+  const manager = new ModelManager();
+  await manager.clear();
+  await manager.downloadModel(TINY_MODEL);
+
+  // simulate a tab closed between the file write and the metadata write
+  const opfs = new OPFSBackend();
+  const fileKey = await manager.cacheManager.getNameFromURL(TINY_MODEL);
+  await opfs.delete(`__metadata__${fileKey}`);
+  expect((await manager.getModels()).length).toBe(0);
+
+  const model = await manager.downloadModel(TINY_MODEL);
+  expect(model.files.length).toBe(1);
+  expect(model.size).toBe(1185376);
+  expect((await manager.getModels()).length).toBe(1);
+});
+
+test.sequential('recover from partial file in cache', async () => {
+  const manager = new ModelManager();
+  await manager.clear();
+  await manager.downloadModel(TINY_MODEL);
+
+  const opfs = new OPFSBackend();
+  const fileKey = await manager.cacheManager.getNameFromURL(TINY_MODEL);
+  const head = await (await opfs.read(fileKey))!.slice(0, 1024).arrayBuffer();
+  await opfs.write(fileKey, new Blob([head]).stream());
+  await opfs.delete(`__metadata__${fileKey}`);
+  expect(await opfs.getSize(fileKey)).toBe(1024);
+
+  const model = await manager.downloadModel(TINY_MODEL);
+  expect(model.files.length).toBe(1);
+  expect(model.files[0].size).toBe(1185376);
+  expect(model.size).toBe(1185376);
 });
 
 test.sequential('download invalid model URL', async () => {

--- a/src/model-manager.test.ts
+++ b/src/model-manager.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from 'vitest';
 import { ModelManager, Model, ModelValidationStatus } from './model-manager';
 import { OPFSBackend } from './storage/opfs';
+import CacheManager from './cache-manager';
 
 const TINY_MODEL =
   'https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf';
@@ -107,13 +108,17 @@ test.skip('interrupt download split model (partial files downloaded)', async () 
   expect((await manager.getModels({ includeInvalid: true })).length).toBe(1);
 });
 
+// the tests below poke the storage directly, so pin the backend instead of the default one
+const opfs = new OPFSBackend();
+const opfsManager = () =>
+  new ModelManager({ cacheManager: new CacheManager([opfs]) });
+
 test.sequential('recover from missing metadata', async () => {
-  const manager = new ModelManager();
+  const manager = opfsManager();
   await manager.clear();
   await manager.downloadModel(TINY_MODEL);
 
   // simulate a tab closed between the file write and the metadata write
-  const opfs = new OPFSBackend();
   const fileKey = await manager.cacheManager.getNameFromURL(TINY_MODEL);
   await opfs.delete(`__metadata__${fileKey}`);
   expect((await manager.getModels()).length).toBe(0);
@@ -125,11 +130,10 @@ test.sequential('recover from missing metadata', async () => {
 });
 
 test.sequential('recover from partial file in cache', async () => {
-  const manager = new ModelManager();
+  const manager = opfsManager();
   await manager.clear();
   await manager.downloadModel(TINY_MODEL);
 
-  const opfs = new OPFSBackend();
   const fileKey = await manager.cacheManager.getNameFromURL(TINY_MODEL);
   const head = await (await opfs.read(fileKey))!.slice(0, 1024).arrayBuffer();
   await opfs.write(fileKey, new Blob([head]).stream());

--- a/src/model-manager.ts
+++ b/src/model-manager.ts
@@ -290,6 +290,8 @@ export class ModelManager {
     const cachedFiles = await this.cacheManager.list();
     let models: Model[] = [];
     for (const file of cachedFiles) {
+      // no metadata means no URL to map back to (i.e. interrupted download)
+      if (!file.metadata.originalURL) continue;
       const shards = ModelManager.parseModelUrl(file.metadata.originalURL);
       const mmprojUrl = file.metadata.mmprojURL;
       const isFirstShard =


### PR DESCRIPTION
Fix https://github.com/ngxson/wllama/issues/268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cached file validation to detect incomplete, outdated, or mismatched files before use.
  - Automatically repairs missing cache metadata and redownloads invalid files when needed.
  - Prevented cached files without sufficient metadata from causing model loading errors.
- **Tests**
  - Added coverage for recovering from missing metadata and truncated cached files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->