### PR TITLE
scripts: guard the missing wasm and the uninitialized submodule

### DIFF
--- a/scripts/build_worker.sh
+++ b/scripts/build_worker.sh
@@ -6,6 +6,10 @@ CURRENT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # change to the llama.cpp directory
 cd $CURRENT_PATH
+if [ ! -e ../llama.cpp/.git ]; then
+  echo "llama.cpp submodule is missing, run: git submodule update --init --recursive"
+  exit 1
+fi
 cd ../llama.cpp
 BUILD_NUMBER="$(git rev-list --count HEAD)"
 SHORT_HASH="$(git rev-parse --short=7 HEAD)"

--- a/scripts/post_build.sh
+++ b/scripts/post_build.sh
@@ -6,7 +6,11 @@ CURRENT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $CURRENT_PATH/..
 
 mkdir -p esm/wasm
-cp src/wasm/wllama.wasm esm/wasm
+if [ -f src/wasm/wllama.wasm ]; then
+  cp src/wasm/wllama.wasm esm/wasm
+else
+  echo "src/wasm/wllama.wasm is missing, run npm run build:wasm to ship it"
+fi
 
 # https://stackoverflow.com/questions/62619058/appending-js-extension-on-relative-import-statements-during-typescript-compilat
 


### PR DESCRIPTION
A small fix for initial installations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build processes now provide a clear instruction when the required `llama.cpp` submodule is not initialized.
  * Post-build processing no longer fails when the WebAssembly output is unavailable; it displays guidance to run the WebAssembly build first.

* **Chores**
  * Improved build-script checks and error handling for smoother development and packaging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->